### PR TITLE
Patch 1

### DIFF
--- a/db/commands.sql
+++ b/db/commands.sql
@@ -166,7 +166,6 @@ INSERT INTO currencies (name, symbol, code, rate) VALUES
     ('Swiss Franc', 'Fr', 'CHF', 1),
     ('Icelandic Króna', 'kr', 'ISK', 1),
     ('Norwegian Krone', 'kr', 'NOK', 1),
-    ('Croatian Kuna', 'kn', 'HRK', 1),
     ('Russian Ruble', '₽', 'RUB', 1),
     ('Turkish Lira', '₺', 'TRY', 1),
     ('Australian Dollar', '$', 'AUD', 1),

--- a/endpoints/cronjobs/createdatabase.php
+++ b/endpoints/cronjobs/createdatabase.php
@@ -178,7 +178,6 @@ if (!file_exists($databaseFile)) {
     ('Swiss Franc', 'Fr', 'CHF', 1),
     ('Icelandic Króna', 'kr', 'ISK', 1),
     ('Norwegian Krone', 'kr', 'NOK', 1),
-    ('Croatian Kuna', 'kn', 'HRK', 1),
     ('Russian Ruble', '₽', 'RUB', 1),
     ('Turkish Lira', '₺', 'TRY', 1),
     ('Australian Dollar', '$', 'AUD', 1),


### PR DESCRIPTION
Croatian Kuna is deprecated currency since 01/01/2023