### PR TITLE
Add workflow for building and publishing Docker images

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,38 @@
+name: Build images
+
+on:
+#  schedule:
+#    - cron: '0 0 * * *' # Midnight every day
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: amd64,arm64,arm
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          install: true
+
+      - name: Build and publish image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ vars.DOCKERHUB_TAG }}:latest
+          platforms: linux/amd64,linux/arm64,linux/arm/v7


### PR DESCRIPTION
This PR adds a Github Actions workflow for building and publishing Docker images for amd64, arm64 (arm/v8) and arm/v7 platforms. The workflow is set up to be manually triggered, however it can be scheduled by un-commenting lines 4-5.

I've tested this myself and the resulting images are currently available for testing at: https://hub.docker.com/r/noevidenz/wallos/tags

The arm64 image appears to be working. Unfortunately I don't currently have a machine available to test amd64 or arm/v7.

### Setup
Add the following repository secrets and variables, added through Settings > Secrets and Variables > Actions:

Secrets: `DOCKERHUB_USERNAME`,`DOCKERHUB_TOKEN`
Variables: `DOCKERHUB_TAG`

Docker Hub username and token can be generated by creating a new Access Token at [Docker Hub > Account Settings > Security](https://hub.docker.com/settings/security).

The value of `DOCKERHUB_TAG` will be the name of the image on Docker Hub, eg: `bellamy/wallos`.

