### PR TITLE
Add migration feature

### DIFF
--- a/db/migrate.php
+++ b/db/migrate.php
@@ -1,0 +1,33 @@
+<?php
+/** @var \SQLite3 $db */
+require_once 'includes/connect_endpoint_crontabs.php';
+
+$completedMigrations = [];
+
+$migrationTableExists = $db
+        ->query('SELECT name FROM sqlite_master WHERE type="table" AND name="migrations"')
+        ->fetchArray(SQLITE3_ASSOC) !== false;
+
+if ($migrationTableExists) {
+    $migrationQuery = $db->query('SELECT migration FROM migrations');
+    while ($row = $migrationQuery->fetchArray(SQLITE3_ASSOC)) {
+        $completedMigrations[] = $row['migration'];
+    }
+}
+
+$allMigrations = glob('migrations/*.php');
+$requiredMigrations = array_diff($allMigrations, $completedMigrations);
+
+if (count($requiredMigrations) === 0) {
+    echo "No migrations to run.\n";
+}
+
+foreach ($requiredMigrations as $migration) {
+    require_once $migration;
+
+    $stmtInsert = $db->prepare('INSERT INTO migrations (migration) VALUES (:migration)');
+    $stmtInsert->bindParam(':migration', $migration, SQLITE3_TEXT);
+    $stmtInsert->execute();
+
+    echo sprintf("Migration %s completed successfully.\n", $migration);
+}

--- a/migrations/000001.php
+++ b/migrations/000001.php
@@ -1,0 +1,8 @@
+<?php
+
+/** @noinspection PhpUndefinedVariableInspection */
+$db->exec('CREATE TABLE IF NOT EXISTS migrations (
+    id INTEGER PRIMARY KEY,
+    migration TEXT NOT NULL,
+    migrated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+)');

--- a/startup.sh
+++ b/startup.sh
@@ -14,6 +14,9 @@ sleep 1
 # Create database if it does not exist
 /usr/local/bin/php /var/www/html/endpoints/cronjobs/createdatabase.php
 
+# Perform any database migrations
+/usr/local/bin/php /var/www/html/db/migrate.php
+
 # Change permissions on the database directory
 chmod -R 755 /var/www/html/db/
 chown -R www-data:www-data /var/www/html/db/


### PR DESCRIPTION
This adds the ability to run database migrations from the `startup.sh` file.

It will allow users to pull the latest docker image and have an updated db without losing any data.