### PR TITLE
add ability to create stable/dev/edge docker builds using git tags and GH actions + enable docker build cache

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -70,5 +70,5 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ vars.DOCKERHUB_TAG }}:latest
+          tags: ${{ vars.DOCKERHUB_TAG }}:${{ steps.image_tag.outputs.TAG }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -72,3 +72,5 @@ jobs:
           push: true
           tags: ${{ vars.DOCKERHUB_TAG }}:${{ steps.image_tag.outputs.TAG }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -4,6 +4,16 @@ on:
 #  schedule:
 #    - cron: '0 0 * * *' # Midnight every day
   workflow_dispatch:
+    inputs:
+      build_type:
+        description: Build Type
+        required: true
+        default: edge
+        type: choice
+        options:
+          - edge
+          - dev
+          - stable
 
 jobs:
   build:
@@ -28,6 +38,32 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           install: true
+        
+      - name: Create the tag
+        id: image_tag
+        run: |
+          choice="${{ inputs.build_type }}"
+          out=""
+          
+          # if the workflow is running on a branch, let the tag be the branch name
+          if [[ $GITHUB_REF == "ref/heads/"* ]]; then
+              echo "TAG=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+              exit 0
+          fi
+          
+          tag="${GITHUB_REF#refs/tags/}"
+          case $choice in 
+              edge)
+                  out="TAG=$tag-edge"
+                  ;;
+              dev)
+                  out="TAG=$tag-dev"
+                  ;;
+              stable)
+                  out="TAG=$tag-stable,latest"
+                  ;;
+          esac
+          echo $out >> $GITHUB_OUTPUT
 
       - name: Build and publish image
         uses: docker/build-push-action@v5

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -60,7 +60,7 @@ jobs:
                   out="TAG=$tag-dev"
                   ;;
               stable)
-                  out="TAG=$tag-stable,latest"
+                  out="TAG=$tag-stable,${{ vars.DOCKERHUB_TAG }}:latest"
                   ;;
           esac
           echo $out >> $GITHUB_OUTPUT

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -46,12 +46,12 @@ jobs:
           out=""
           
           # if the workflow is running on a branch, let the tag be the branch name
-          if [[ $GITHUB_REF == "ref/heads/"* ]]; then
-              echo "TAG=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+          if [[ $GITHUB_REF == "refs/heads/"* ]] ; then
+              echo "TAG=${GITHUB_REF#'refs/heads/'}" >> $GITHUB_OUTPUT
               exit 0
           fi
           
-          tag="${GITHUB_REF#refs/tags/}"
+          tag="${GITHUB_REF#'refs/tags/'}"
           case $choice in 
               edge)
                   out="TAG=$tag-edge"


### PR DESCRIPTION
as discussed in #51, i have added the option to mark the image being built for a git tag as `dev`/`edge`/`stable` (stable also being `latest`).

This is how the workflow dispatch menu would look like:
![image](https://github.com/ellite/Wallos/assets/39442192/43a88232-e87c-4854-b897-acca8ce15975)

And all the tags published are here: https://hub.docker.com/r/roguedbear/wallos-test/tags?page=1&ordering=last_updated
![image](https://github.com/ellite/Wallos/assets/39442192/8c8c0a7c-350a-4492-8091-33e1290d1b47)


For the branch input:
- if branch is a git tag, then the "Build Type" option would be used (as shown in the tags)
- if the branch is not a git tag, then the branch name would be used as the tag.
- `latest` tag is only published when `stable` build type is selected

---

Also, optionally i noticed that image build time was around 15minutes, and image was being built entirely everytime, so I have enabled build cache too. So hopefully once an image is built, on future builds, caches for unchanged layers should not get invalidated resulting in faster build time.

![image](https://github.com/ellite/Wallos/assets/39442192/96b81e8b-511d-46a0-8563-1614c5476675)
https://github.com/RoguedBear/Wallos/actions/workflows/build-images.yml

---

Please let me know if you have additional feedbacks or want something changed.

closes #51 