### PR TITLE
docs: add deploy to Zeabur as another installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Wallos: Open-Source Personal Subscription Tracker
     - [Baremetal](#baremetal-1)
       - [Updating](#updating)
     - [Docker](#docker-1)
+    - [Zeabur](#deploy-to-zeabur)
     - [Docker-Compose](#docker-compose)
 - [Usage](#usage)
 - [Contributing](#contributing)
@@ -92,6 +93,12 @@ docker run -d --name wallos -v /path/to/config/wallos/db:/var/www/html/db \
 -e TZ=Europe/Berlin -p 8282:80 --restart unless-stopped \
 bellamy/wallos:latest
 ```
+
+#### Deploy to Zeabur
+
+Click on the button below to deploy Wallos on Zeabur.
+
+[![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/templates/ELBR4V)
 
 ### Docker Compose
 


### PR DESCRIPTION
[Zeabur](https://zeabur.com) is a platform for hosting services with one click.
I've made a template for Wallos so that people can install their own Wallos with one click.
Template preview: https://zeabur.com/templates/ELBR4V
<img width="1512" alt="image" src="https://github.com/ellite/Wallos/assets/63531512/10a016da-1ab9-433f-aca3-581b6d0133bd">
Succesful deployment:
<img width="1512" alt="image" src="https://github.com/ellite/Wallos/assets/63531512/a6d85597-011c-4d10-8aa2-04ad6b79c6e8">
<img width="1512" alt="image" src="https://github.com/ellite/Wallos/assets/63531512/4c631b95-b940-42e0-b786-4a062d466196">
