### PR TITLE
Optimize Dockerfile apk usage to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM php:8.0.5-fpm-alpine
 WORKDIR /var/www/html
 
 # Update packages
-RUN apk update && apk upgrade
+RUN apk upgrade --no-cache
 
 # Install SQLite3 and its dependencies
 RUN apk add --no-cache sqlite-dev \


### PR DESCRIPTION
Eliminate `apk update` command and explicitly use `apk upgrade` with `--no-cache` to minimize temp file residue.