### PR TITLE
Fix message for when a payment method is deleted

### DIFF
--- a/endpoints/payments/delete.php
+++ b/endpoints/payments/delete.php
@@ -8,10 +8,10 @@ if (isset($_SESSION['loggedin']) && $_SESSION['loggedin'] === true) {
         $deleteQuery = "DELETE FROM payment_methods WHERE id = :paymentMethodId";
         $deleteStmt = $db->prepare($deleteQuery);
         $deleteStmt->bindParam(':paymentMethodId', $paymentMethodId, SQLITE3_INTEGER);
-    
+
         if ($deleteStmt->execute()) {
             $success['success'] = true;
-            $success['message'] = translate('payment_method_added_successfuly', $i18n);
+            $success['message'] = translate('payment_method_removed', $i18n);
             $json = json_encode($success);
             header('Content-Type: application/json');
             echo $json;

--- a/includes/i18n/en.php
+++ b/includes/i18n/en.php
@@ -141,6 +141,7 @@ $i18n = [
     "add_custom_payment" => "Add Custom Payment Method",
     "payment_method_name" => "Payment Method Name",
     "payment_method_added_successfuly" => "Payment method added successfully",
+    "payment_method_removed" => "Payment method removed",
     "disable"         => "Disable",
     "enable"          => "Enable",
     "rename_payment_method" => "Rename Payment Method",

--- a/includes/i18n/pt_br.php
+++ b/includes/i18n/pt_br.php
@@ -167,7 +167,7 @@ $i18n = [
     "category_in_use" => "Essa categoria está em uso em uma assinatura e não pode ser removida",
     "failed_remove_category" => "Erro ao remover categoria",
     "category_saved"  => "Categoria salva",
-    "category_removed" => "Category excluída",
+    "category_removed" => "Categoria excluída",
     "sort_order_saved" => "Direção de ordenação salva",
     // Currency
     "currency_saved"  => "foi salva.",

--- a/includes/i18n/pt_br.php
+++ b/includes/i18n/pt_br.php
@@ -139,6 +139,7 @@ $i18n = [
     "add_custom_payment" => "Adicionar um método de pagamento personalizado",
     "payment_method_name" => "Nome do método de pagamento",
     "payment_method_added_successfuly" => "Método de pagamento adicionado com sucesso",
+    "payment_method_removed" => "Método de pagamento excluído",
     "disable"         => "Desativar",
     "enable"          => "Ativar",
     "rename_payment_method" => "Renomear método de pagamento",


### PR DESCRIPTION
The `payment_method_added_successfully` message was being displayed on the delete operation. It's now been replaced with a  proper new message.

There's also a small typo fix that is unrelated to the issue. Please let me know in case you'd prefer if to be submitted as a separate PR.