### PR TITLE
follow redirect for google search

### DIFF
--- a/endpoints/logos/search.php
+++ b/endpoints/logos/search.php
@@ -8,6 +8,7 @@
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, $url);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
 
         // Convert all environment variable keys to lowercase
         $envVars = array_change_key_case($_SERVER, CASE_LOWER);


### PR DESCRIPTION
Can solve issue https://github.com/ellite/Wallos/issues/221

sometimes google will replace the domain with a 301 redirect. like `https://www.google.com` to `https://www.google.com.hk` 