### PR TITLE
[Bug fix] On initial registration page, logo can be cut off

### DIFF
--- a/includes/version.php
+++ b/includes/version.php
@@ -1,3 +1,3 @@
 <?php
-    $version = "v1.18.2";
+    $version = "v1.18.3";
 ?>

--- a/styles/login.css
+++ b/styles/login.css
@@ -35,6 +35,12 @@ body, html {
     }
 }
 
+@media (max-height: 768px) {
+    .content {
+        height: auto;
+    }
+}
+
 .container > header {
     text-align: center;
 }


### PR DESCRIPTION
Resolves https://github.com/ellite/Wallos/issues/179

the `height: 100%` on the `.content` class seems to have been cutting it off if the screen size was around 750px and below