### PR TITLE
fix: custom  headers not being applied on webhook

### DIFF
--- a/endpoints/cronjobs/sendnotifications.php
+++ b/endpoints/cronjobs/sendnotifications.php
@@ -477,8 +477,9 @@
                     curl_setopt($ch, CURLOPT_URL, $webhook['url']);
                     curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $webhook['request_method']);
                     curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($payload_json));
-                    if (!empty($customheaders)) {
-                        curl_setopt($ch, CURLOPT_HTTPHEADER, $webhook['headers']);
+                    if (!empty($webhook['headers'])) {
+                        $customheaders = preg_split("/\r\n|\n|\r/", $webhook['headers']);
+                        curl_setopt($ch, CURLOPT_HTTPHEADER, $customheaders);
                     }
                     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 


### PR DESCRIPTION
This request fixes the issue where custom headers are not being applied due to an check on the wrong variable.