### PR TITLE
removed version line from docker compose yml files

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,6 @@ bellamy/wallos:latest
 ### Docker Compose
 
 ```
-version: '3.0'
-
 services:
   wallos:
     container_name: wallos


### PR DESCRIPTION
Specifying a version is Docker Compose is now obsolete. Using version will throw a warning message. Removed this line in the Docker Compose code.