### PR TITLE
Change iCalendar subscription event to all day

### DIFF
--- a/api/subscriptions/get_ical_feed.php
+++ b/api/subscriptions/get_ical_feed.php
@@ -165,8 +165,8 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" || $_SERVER["REQUEST_METHOD"] === "GET
         $uid = uniqid();
         $summary = "Wallos: " . $subscription['name'];
         $description = "Price: {$subscription['currency']}{$subscription['price']}\\nCategory: {$subscription['category']}\\nPayment Method: {$subscription['payment_method']}\\nPayer: {$subscription['payer_user']}\\nNotes: {$subscription['notes']}";
-        $dtstart = (new DateTime($subscription['next_payment']))->format('Ymd\THis\Z');
-        $dtend = (new DateTime($subscription['next_payment']))->modify('+1 hour')->format('Ymd\THis\Z');
+        $dtstart = (new DateTime($subscription['next_payment']))->format('Ymd');
+        $dtend = (new DateTime($subscription['next_payment']))->format('Ymd');
         $location = isset($subscription['url']) ? $subscription['url'] : '';
         $alarm_trigger = '-' . $subscription['trigger'] . 'D';
 


### PR DESCRIPTION
Since we do not have an exact time for the due date of a subscription, i suggest changing the event to an all day event for the ical feed.