### PR TITLE
Fix PUID and PGID handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /var/www/html
 
 # Update packages and install dependencies
 RUN apk upgrade --no-cache && \
-    apk add --no-cache sqlite-dev libpng libpng-dev libjpeg-turbo libjpeg-turbo-dev freetype freetype-dev curl autoconf libgomp icu-dev icu-data-full nginx dcron tzdata imagemagick imagemagick-dev libzip-dev sqlite libwebp-dev && \
+    apk add --no-cache shadow sqlite-dev libpng libpng-dev libjpeg-turbo libjpeg-turbo-dev freetype freetype-dev curl autoconf libgomp icu-dev icu-data-full nginx dcron tzdata imagemagick imagemagick-dev libzip-dev sqlite libwebp-dev && \
     docker-php-ext-install pdo pdo_sqlite calendar && \
     docker-php-ext-enable pdo pdo_sqlite && \
     docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,6 @@ RUN dos2unix /etc/cron.d/cronjobs && \
     chmod 0644 /etc/cron.d/cronjobs && \
     /usr/bin/crontab /etc/cron.d/cronjobs && \
     mkdir /var/log/cron && \
-    chown -R www-data:www-data /var/www/html && \
     chmod +x /var/www/html/startup.sh && \
     echo 'pm.max_children = 15' >> /usr/local/etc/php-fpm.d/zz-docker.conf && \
     echo 'pm.max_requests = 500' >> /usr/local/etc/php-fpm.d/zz-docker.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN dos2unix /etc/cron.d/cronjobs && \
     chmod 0644 /etc/cron.d/cronjobs && \
     /usr/bin/crontab /etc/cron.d/cronjobs && \
     mkdir /var/log/cron && \
+    chown -R www-data:www-data /var/www/html && \
     chmod +x /var/www/html/startup.sh && \
     echo 'pm.max_children = 15' >> /usr/local/etc/php-fpm.d/zz-docker.conf && \
     echo 'pm.max_requests = 500' >> /usr/local/etc/php-fpm.d/zz-docker.conf

--- a/README.md
+++ b/README.md
@@ -114,9 +114,11 @@ See instructions to run Wallos below.
 ```bash
 docker run -d --name wallos -v /path/to/config/wallos/db:/var/www/html/db \
 -v /path/to/config/wallos/logos:/var/www/html/images/uploads/logos \
--e TZ=Europe/Berlin -p 8282:80 --restart unless-stopped \
+-e TZ=Europe/Berlin -e PUID=82 -e PGID=82 -p 8282:80 --restart unless-stopped \
 bellamy/wallos:latest
 ```
+
+Note: PUID and PGUID are optional, defaults to 82. Will let you run as an arbitrary user.
 
 ### Docker Compose
 
@@ -129,6 +131,9 @@ services:
       - "8282:80/tcp"
     environment:
       TZ: 'America/Toronto'
+      # PUID and PGUID are optional, defaults to 82. Will let you run as an arbitrary user.
+      # PUID: 82 
+      # PGID: 82
     # Volumes store your data between container upgrades
     volumes:
       - './db:/var/www/html/db'

--- a/startup.sh
+++ b/startup.sh
@@ -7,10 +7,10 @@ echo "Startup script is running..." > /var/log/startup.log
 PUID=${PUID:-82}
 PGID=${PGID:-82}
 
-# Create a new user and group
-addgroup -g $PGID appgroup
-adduser -D -u $PUID -G appgroup appuser
-chown -R appuser:appgroup /var/www/html
+# Change the www-data user id and group id to be the user-specified ones
+groupmod -o -g "$PGID" www-data
+usermod -o -u "$PUID" www-data
+chown -R www-data:www-data /var/www/html
 
 # Start both PHP-FPM and Nginx
 php-fpm & nginx -g 'daemon off;' & touch ~/startup.txt
@@ -29,13 +29,13 @@ sleep 1
 
 # Change permissions on the database directory
 chmod -R 755 /var/www/html/db/
-chown -R appuser:appgroup /var/www/html/db/
+chown -R www-data:www-data /var/www/html/db/
 
 mkdir -p /var/www/html/images/uploads/logos/avatars
 
 # Change permissions on the logos directory
 chmod -R 755 /var/www/html/images/uploads/logos
-chown -R appuser:appgroup /var/www/html/images/uploads/logos
+chown -R www-data:www-data /var/www/html/images/uploads/logos
 
 # Remove crontab for the user
 crontab -d -u root

--- a/startup.sh
+++ b/startup.sh
@@ -2,12 +2,15 @@
 
 echo "Startup script is running..." > /var/log/startup.log
 
-# If the PUID or PGID environment variables are set, create a new user and group
-if [ ! -z "$PUID" ] && [ ! -z "$PGID" ]; then
-    addgroup -g $PGID appgroup
-    adduser -D -u $PUID -G appgroup appuser
-    chown -R appuser:appgroup /var/www/html
-fi
+# Default the PUID and PGID environment variables to 82, otherwise
+# set to the user defined ones.
+PUID=${PUID:-82}
+PGID=${PGID:-82}
+
+# Create a new user and group
+addgroup -g $PGID appgroup
+adduser -D -u $PUID -G appgroup appuser
+chown -R appuser:appgroup /var/www/html
 
 # Start both PHP-FPM and Nginx
 php-fpm & nginx -g 'daemon off;' & touch ~/startup.txt
@@ -26,13 +29,13 @@ sleep 1
 
 # Change permissions on the database directory
 chmod -R 755 /var/www/html/db/
-chown -R www-data:www-data /var/www/html/db/
+chown -R appuser:appgroup /var/www/html/db/
 
 mkdir -p /var/www/html/images/uploads/logos/avatars
 
 # Change permissions on the logos directory
 chmod -R 755 /var/www/html/images/uploads/logos
-chown -R www-data:www-data /var/www/html/images/uploads/logos
+chown -R appuser:appgroup /var/www/html/images/uploads/logos
 
 # Remove crontab for the user
 crontab -d -u root


### PR DESCRIPTION
# Background

In https://github.com/ellite/Wallos/issues/33 there was some work done to support PUID and PGID, however it appears that the use of `www-data:www-data` was left in the Dockerfile and startup.sh file leading to the database and logos being 
owned by the wrong user (some things were appuser:appgroup, some where www-data:www-data)

# What does this PR do?

This PR gets rid of [www-data](appuser:appgroup) entirely and uses www-data:www-data exclusively by defaulting PUID/PGID to 82:82 (same ID that's being used), and otherwise using the user-defined PUID/PGID by setting the ID on startup.

This means that the user id and group id can be freely changed and permissions will float to whatever you specify in the container.

In order to do this we need to add the `shadow` package which adds groupmod/usermod commands.

# How did I test this?

1. Published a container to ghcr.io/jules2689/wallos:1.0.2 (took a few attempts from 1.0.0!)
2. Changed my deploy to use this container
3. Checked the permissions of the database and logos were the PUID and PGID I set
4. Tried updating an entry in wallos to make sure the database is still writable (as this usually manifests in a read only DB in my experience)
5. Uploaded a logo and made sure it worked

Closes https://github.com/ellite/Wallos/issues/617