### PR TITLE
Enable IPv6 environments by configuring a dual-stack listen in Nginx

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -22,7 +22,7 @@ http {
     keepalive_timeout  65;
 
     server {
-        listen       80;
+        listen       [::]:80 ipv6only=off;
         server_name  localhost;
 
         location / {

--- a/nginx.default.conf
+++ b/nginx.default.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen [::]:80 ipv6only=off;
     server_name your_domain_or_ip; # Change to your domain or IP
 
     root /var/www/html; # Change to your web root directory


### PR DESCRIPTION
Enabling this application to function when in an IPv6 environment.
The change maintains IPv4 compatibility by setting _ipv6only_ to _off_ as per the Nginx documentation for the [listen directive](https://nginx.org/en/docs/http/ngx_http_core_module.html#listen).

I have tested the change when the Docker network the container is attached to is IPv4 only and when IPv6 is enabled. Both configurations work as expected.