### PR TITLE
fixing decoding of header value from database for webhooks

### DIFF
--- a/endpoints/cronjobs/sendnotifications.php
+++ b/endpoints/cronjobs/sendnotifications.php
@@ -630,7 +630,7 @@ while ($userToNotify = $usersToNotify->fetchArray(SQLITE3_ASSOC)) {
             
                         // Add headers if they exist
                         if (!empty($webhook['headers'])) {
-                            $customheaders = preg_split("/\r\n|\n|\r/", $webhook['headers']);
+                            $customheaders = json_decode($webhook["headers"], true);
                             curl_setopt($ch, CURLOPT_HTTPHEADER, $customheaders);
                         }
             


### PR DESCRIPTION
Without this, there are issues with the headers sent to the webhook endpoint.

I found that the handling of the webhook headers value was different in the `endpoints/notifications/testwebhooknotifications.php` code to the `endpoints/cronjobs/sendnotifications.php` code.

original data
```
wallos  | ...
wallos  | Accept: */*
wallos  | ["Content-Type: application/json"]
wallos  | Content-Length: 156
wallos  | ...
```

fixed data
```
wallos  | ...
wallos  | Accept: */*
wallos  | Content-Type: application/json
wallos  | Content-Length: 156
wallos  | ...
```