### PR TITLE
No telegram notification cause by message text empty(unicode)

### DIFF
--- a/endpoints/cronjobs/sendnotifications.php
+++ b/endpoints/cronjobs/sendnotifications.php
@@ -470,7 +470,7 @@ while ($userToNotify = $usersToNotify->fetchArray(SQLITE3_ASSOC)) {
 
                     $data = array(
                         'chat_id' => $telegram['chatId'],
-                        'text' => $message
+                        'text' => mb_convert_encoding($message, 'UTF-8', 'auto')
                     );
 
                     $data_string = json_encode($data);


### PR DESCRIPTION
This pull request addresses an issue where Telegram message notifications were not being sent due to malformed UTF-8 characters in the message text. The Telegram API returned the following error:

```
For user: admin

Subscription: test4
Next payment date: 2025-07-17
Current date: 2025-07-17
Difference: 0

admin, the following subscriptions are up for renewal:
test4 for Rp�121,233.00 (Today)
{"ok":false,"error_code":400,"description":"Bad Request: message text is empty"}Telegram Notifications sent
```
Despite the message appearing valid, characters such as currency symbols (e.g., Rp) were not properly encoded, which caused json_encode() to fail silently. Also, for this case(Indonesian Rupiah) it should be `Rp.`.

**Changes Made**
Applied mb_convert_encoding() to ensure the text field is UTF-8 encoded before passing it to json_encode().

Updated the $data array construction to:

`'text' => mb_convert_encoding($message, 'UTF-8', 'auto')`
This ensures proper handling of special characters in Telegram messages.

**Test Results**

- Verified that messages with special characters are now successfully delivered via Telegram.
- Confirmed that json_encode() no longer produces encoding errors.

Notes:

- If similar issues occur in other parts of the code, additional UTF-8 validation or sanitization may be needed earlier in the processing pipeline.
- I did not test other platforms, but I believe this workaround should be implemented to ensure there are no encoding errors across all integrations.