### PR TITLE
Make container shutdown instant & graceful: add dumb-init and signal-aware startup.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /var/www/html
 
 # Update packages and install dependencies
 RUN apk upgrade --no-cache && \
-    apk add --no-cache shadow sqlite-dev libpng libpng-dev libjpeg-turbo libjpeg-turbo-dev freetype freetype-dev curl autoconf libgomp icu-dev icu-data-full nginx dcron tzdata imagemagick imagemagick-dev libzip-dev sqlite libwebp-dev && \
+    apk add --no-cache dumb-init shadow sqlite-dev libpng libpng-dev libjpeg-turbo libjpeg-turbo-dev freetype freetype-dev curl autoconf libgomp icu-dev icu-data-full nginx dcron tzdata imagemagick imagemagick-dev libzip-dev sqlite libwebp-dev && \
     docker-php-ext-install pdo pdo_sqlite calendar && \
     docker-php-ext-enable pdo pdo_sqlite && \
     docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp && \
@@ -45,5 +45,7 @@ EXPOSE 80
 
 ARG SOFTWARE_VERSION=1.20.0
 
+ENTRYPOINT ["dumb-init", "--"]
+
 # Start both PHP-FPM, Nginx
-CMD ["sh", "-c", "/var/www/html/startup.sh"]
+CMD ["/var/www/html/startup.sh"]


### PR DESCRIPTION
This PR fixes Docker/Podman container failed shutdown forcing a SIGKILL to bring take down the container, by:

- Running a tiny init (dumb-init) as PID 1 so signals are forwarded and zombies are reaped.
- Rewriting `startup.sh` to start php-fpm, nginx, and crond in the background, trap TERM/INT/QUIT, and translate them to the daemons’ graceful stops (`nginx -s quit`, `kill -QUIT $PHP_FPM_PID`).
- Running `wait` to wait for sub-processes to complete, rather than relying on `tail -f /dev/null`

Nginx documents `QUIT` as graceful shutdown; PHP-FPM treats `SIGQUIT` as graceful stop. `dumb-init` forwards signals correctly from PID 1. 

## Rationale

Today PID 1 is the shell running startup.sh, which backgrounds services and uses a “keepalive” like `tail -f /dev/null`. Signals sent to the container don’t reach nginx/php-fpm reliably, and PID 1 shell semantics make termination non-intuitive. Using a small init (e.g., dumb-init) is the standard fix to forward signals and reap children. 