### PR TITLE
Add Dockerfile HEALTHCHECK command and basic healthcheck reply

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,5 +47,9 @@ ARG SOFTWARE_VERSION=1.20.0
 
 ENTRYPOINT ["dumb-init", "--"]
 
+# Requires docker engine 25+ for the --start-interval flag
+HEALTHCHECK --interval=2m --timeout=2s --start-period=20s --start-interval=5s --retries=3 \
+    CMD ["curl", "-fsS", "127.0.0.1/health.php"]
+
 # Start both PHP-FPM, Nginx
 CMD ["/var/www/html/startup.sh"]

--- a/health.php
+++ b/health.php
@@ -1,0 +1,7 @@
+<?php
+
+header('Content-Type: text/plain');
+http_response_code(200);
+
+echo 'OK';
+exit;


### PR DESCRIPTION
This PR adds 2 things:
1. "API" response of 200 OK to /health.php, super light-weight health-check response.
2. Docker HEALTHCHECK which allows detecting unhealthy states of the app.

Because I used `--start-interval` in the healthcheck config, it requires docker engine 25+, this allows much faster startup health detection, but it can be potentially removed if it blocks some users.