### PR TITLE
fix: add autocomplete attribute for inputs

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -61,7 +61,7 @@ $loginDisabledAllowed = $userCount == 1 && $settings['registrations_open'] == 0;
             </div>
             <div class="form-group">
                 <label for="maxUsers"><?= translate('maximum_number_users', $i18n) ?></label>
-                <input type="number" id="maxUsers" value="<?= $settings['max_users'] ?>" />
+                <input type="number" id="maxUsers" autocomplete="off" value="<?= $settings['max_users'] ?>" />
             </div>
             <div class="settings-notes">
                 <p>
@@ -94,7 +94,7 @@ $loginDisabledAllowed = $userCount == 1 && $settings['registrations_open'] == 0;
             ?>
             <div class="form-group">
                 <label for="serverUrl"><?= translate('server_url', $i18n) ?></label>
-                <input type="text" id="serverUrl" value="<?= $settings['server_url'] ?>" />
+                <input type="text" id="serverUrl" autocomplete="off" value="<?= $settings['server_url'] ?>" />
             </div>
             <div class="settings-notes">
                 <p>
@@ -190,13 +190,16 @@ $loginDisabledAllowed = $userCount == 1 && $settings['registrations_open'] == 0;
             </div>
             <h2><?= translate('create_user', $i18n) ?></h2>
             <div class="form-group">
-                <input type="text" id="newUsername" placeholder="<?= translate('username', $i18n) ?>" />
+                <input type="text" id="newUsername" autocomplete="off"
+                    placeholder="<?= translate('username', $i18n) ?>" />
             </div>
             <div class="form-group">
-                <input type="email" id="newEmail" placeholder="<?= translate('email', $i18n) ?>" />
+                <input type="email" id="newEmail" autocomplete="off"
+                    placeholder="<?= translate('email', $i18n) ?>" />
             </div>
             <div class="form-group-inline">
-                <input type="password" id="newPassword" placeholder="<?= translate('password', $i18n) ?>" />
+                <input type="password" id="newPassword" autocomplete="off"
+                    placeholder="<?= translate('password', $i18n) ?>" />
                 <input type="submit" class="thin" value="<?= translate('add', $i18n) ?>" id="addUserButton"
                     onClick="addUserButton()" />
             </div>
@@ -217,41 +220,47 @@ $loginDisabledAllowed = $userCount == 1 && $settings['registrations_open'] == 0;
                 <label for="oidcEnabled"><?= translate('oidc_oauth_enabled', $i18n) ?></label>
             </div>
             <div class="form-group">
-                <input type="text" id="oidcName" placeholder="Provider Name" value="<?= $oidcSettings['name'] ?>" />
+                <input type="text" id="oidcName" placeholder="Provider Name" autocomplete="off"
+                    value="<?= $oidcSettings['name'] ?>" />
             </div>
             <div class="form-group">
-                <input type="text" id="oidcClientId" placeholder="Client ID" value="<?= $oidcSettings['client_id'] ?>" />
+                <input type="text" id="oidcClientId" placeholder="Client ID" autocomplete="off"
+                    value="<?= $oidcSettings['client_id'] ?>" />
             </div>
             <div class="form-group">
-                <input type="text" id="oidcClientSecret" placeholder="Client Secret" value="<?= $oidcSettings['client_secret'] ?>" />
+                <input type="text" id="oidcClientSecret" placeholder="Client Secret" autocomplete="off"
+                    value="<?= $oidcSettings['client_secret'] ?>" />
             </div>
             <div class="form-group">
-                <input type="text" id="oidcAuthUrl" placeholder="Auth URL" value="<?= $oidcSettings['authorization_url'] ?>" />
+                <input type="text" id="oidcAuthUrl" placeholder="Auth URL" autocomplete="off"
+                    value="<?= $oidcSettings['authorization_url'] ?>" />
             </div>
             <div class="form-group">
-                <input type="text" id="oidcTokenUrl" placeholder="Token URL" value="<?= $oidcSettings['token_url'] ?>" />
+                <input type="text" id="oidcTokenUrl" placeholder="Token URL" autocomplete="off"
+                    value="<?= $oidcSettings['token_url'] ?>" />
             </div>
             <div class="form-group">
-                <input type="text" id="oidcUserInfoUrl" placeholder="User Info URL"
+                <input type="text" id="oidcUserInfoUrl" placeholder="User Info URL" autocomplete="off"
                     value="<?= $oidcSettings['user_info_url'] ?>" />
             </div>
             <div class="form-group">
-                <input type="text" id="oidcRedirectUrl" placeholder="Redirect URL"
+                <input type="text" id="oidcRedirectUrl" placeholder="Redirect URL" autocomplete="off"
                     value="<?= $oidcSettings['redirect_url'] ?>" />
             </div>
             <div class="form-group">
-                <input type="text" id="oidcLogoutUrl" placeholder="Logout URL"
+                <input type="text" id="oidcLogoutUrl" placeholder="Logout URL" autocomplete="off"
                     value="<?= $oidcSettings['logout_url'] ?>" />
             </div>
             <div class="form-group">
-                <input type="text" id="oidcUserIdentifierField" placeholder="User Identifier Field"
+                <input type="text" id="oidcUserIdentifierField" placeholder="User Identifier Field" autocomplete="off"
                     value="<?= $oidcSettings['user_identifier_field'] ?>" />
             </div>
             <div class="form-group">
-                <input type="text" id="oidcScopes" placeholder="Scopes" value="<?= $oidcSettings['scopes'] ?>" />
+                <input type="text" id="oidcScopes" placeholder="Scopes" autocomplete="off"
+                    value="<?= $oidcSettings['scopes'] ?>" />
             </div>
             <div class="form-group">
-                <input type="hidden" id="oidcAuthStyle" placeholder="Auth Style"
+                <input type="hidden" id="oidcAuthStyle" placeholder="Auth Style" autocomplete="off"
                     value="<?= $oidcSettings['auth_style'] ?>" />
             </div>
             <div class="form-group-inline">
@@ -277,10 +286,10 @@ $loginDisabledAllowed = $userCount == 1 && $settings['registrations_open'] == 0;
         </header>
         <div class="admin-form">
             <div class="form-group-inline">
-                <input type="text" name="smtpaddress" id="smtpaddress"
+                <input type="text" name="smtpaddress" id="smtpaddress" autocomplete="off"
                     placeholder="<?= translate('smtp_address', $i18n) ?>" value="<?= $settings['smtp_address'] ?>" />
-                <input type="text" name="smtpport" id="smtpport" placeholder="<?= translate('port', $i18n) ?>"
-                    class="one-third" value="<?= $settings['smtp_port'] ?>" />
+                <input type="text" name="smtpport" id="smtpport" autocomplete="off"
+                    placeholder="<?= translate('port', $i18n) ?>" class="one-third" value="<?= $settings['smtp_port'] ?>" />
             </div>
             <div class="form-group-inline">
                 <div>
@@ -300,16 +309,16 @@ $loginDisabledAllowed = $userCount == 1 && $settings['registrations_open'] == 0;
                 </div>
             </div>
             <div class="form-group-inline">
-                <input type="text" name="smtpusername" id="smtpusername"
+                <input type="text" name="smtpusername" id="smtpusername" autocomplete="off"
                     placeholder="<?= translate('smtp_username', $i18n) ?>" value="<?= $settings['smtp_username'] ?>" />
             </div>
             <div class="form-group-inline">
-                <input type="password" name="smtppassword" id="smtppassword"
+                <input type="password" name="smtppassword" id="smtppassword" autocomplete="off"
                     placeholder="<?= translate('smtp_password', $i18n) ?>" value="<?= $settings['smtp_password'] ?>" />
             </div>
             <div class="form-group-inline">
-                <input type="text" name="fromemail" id="fromemail" placeholder="<?= translate('from_email', $i18n) ?>"
-                    value="<?= $settings['from_email'] ?>" />
+                <input type="text" name="fromemail" id="fromemail" autocomplete="off"
+                    placeholder="<?= translate('from_email', $i18n) ?>" value="<?= $settings['from_email'] ?>" />
             </div>
             <div class="buttons">
                 <input type="button" class="secondary-button thin mobile-grow" value="<?= translate('test', $i18n) ?>"

--- a/login.php
+++ b/login.php
@@ -327,11 +327,11 @@ if (isset($_GET['error']) && $_GET['error'] == "oidc_user_not_found") {
                 <?php if (!$password_login_disabled) { ?>
                     <div class="form-group">
                         <label for="username"><?= translate('username', $i18n) ?>:</label>
-                        <input type="text" id="username" name="username" required>
+                        <input type="text" id="username" name="username" autocomplete="username" required>
                     </div>
                     <div class="form-group">
                         <label for="password"><?= translate('password', $i18n) ?>:</label>
-                        <input type="password" id="password" name="password" required>
+                        <input type="password" id="password" name="password" autocomplete="current-password" required>
                     </div>
                     <?php
                     if (!$demoMode) {

--- a/logos.php
+++ b/logos.php
@@ -53,7 +53,7 @@
 
 <body>
     <form id="search-form">
-        <input type="text" name="search" id="search">
+        <input type="text" name="search" id="search" autocomplete="off">
         <input type="submit" value="Search">
     </form>
     <div id="image-results">

--- a/passwordreset.php
+++ b/passwordreset.php
@@ -161,7 +161,7 @@ if (isset($_POST['password']) && $_POST['password'] != "" && isset($_POST['confi
                         ?>
                         <div class="form-group">
                             <label for="email"><?= translate('email', $i18n) ?>:</label>
-                            <input type="text" id="email" name="email" required>
+                            <input type="text" id="email" name="email" autocomplete="email" required>
                         </div>
                         <div class="form-group">
                             <input type="submit" value="<?= translate('reset_password', $i18n) ?>">
@@ -190,11 +190,11 @@ if (isset($_POST['password']) && $_POST['password'] != "" && isset($_POST['confi
                             <input type="hidden" name="token" value="<?= $token ?>">
                             <input type="hidden" name="email" value="<?= $email ?>">
                             <label for="password"><?= translate('password', $i18n) ?>:</label>
-                            <input type="password" id="password" name="password" required>
+                            <input type="password" id="password" name="password" autocomplete="new-password" required>
                         </div>
                         <div class="form-group">
                             <label for="confirm_password"><?= translate('confirm_password', $i18n) ?>:</label>
-                            <input type="password" id="confirm_password" name="confirm_password" required>
+                            <input type="password" id="confirm_password" name="confirm_password" autocomplete="new-password" required>
                         </div>
                         <div class="form-group">
                             <input type="submit" value="<?= translate('reset_password', $i18n) ?>">

--- a/profile.php
+++ b/profile.php
@@ -65,23 +65,28 @@ require_once 'includes/header.php';
                         </div>
                         <div class="form-group">
                             <label for="firstname"><?= translate('firstname', $i18n) ?>:</label>
-                            <input type="text" id="firstname" name="firstname" value="<?= $userData['firstname'] ?>">
+                            <input type="text" id="firstname" name="firstname" autocomplete="given-name"
+                                value="<?= $userData['firstname'] ?>">
                         </div>
                         <div class="form-group">
                             <label for="lastname"><?= translate('lastname', $i18n) ?>:</label>
-                            <input type="text" id="lastname" name="lastname" value="<?= $userData['lastname'] ?>">
+                            <input type="text" id="lastname" name="lastname" autocomplete="family-name"
+                                value="<?= $userData['lastname'] ?>">
                         </div>
                         <div class="form-group">
                             <label for="email"><?= translate('email', $i18n) ?>:</label>
-                            <input type="email" id="email" name="email" value="<?= $userData['email'] ?>" required>
+                            <input type="email" id="email" name="email" autocomplete="email"
+                                value="<?= $userData['email'] ?>" required>
                         </div>
                         <div class="form-group">
                             <label for="password"><?= translate('password', $i18n) ?>:</label>
-                            <input type="password" id="password" name="password" <?= $demoMode ? 'disabled title="Not available on Demo Mode"' : '' ?>>
+                            <input type="password" id="password" name="password" autocomplete="new-password"
+                                <?= $demoMode ? 'disabled title="Not available on Demo Mode"' : '' ?>>
                         </div>
                         <div class="form-group">
                             <label for="confirm_password"><?= translate('confirm_password', $i18n) ?>:</label>
-                            <input type="password" id="confirm_password" name="confirm_password" <?= $demoMode ? 'disabled title="Not available on Demo Mode"' : '' ?>>
+                            <input type="password" id="confirm_password" name="confirm_password" autocomplete="new-password"
+                                <?= $demoMode ? 'disabled title="Not available on Demo Mode"' : '' ?>>
                         </div>
                         <?php
                         $currencies = array();
@@ -173,7 +178,7 @@ require_once 'includes/header.php';
                                     <p class="totp-secret" id="totp-secret-code"></p>
                                     <div class="form-group-inline">
                                         <input type="hidden" name="totp-secret" id="totp-secret" value="" />
-                                        <input type="text" id="totp" name="totp"
+                                        <input type="text" id="totp" name="totp" autocomplete="one-time-code"
                                             placeholder="<?= translate("totp_code", $i18n) ?>" />
                                         <input type="button" value="<?= translate('enable', $i18n) ?>" id="enableTotpButton"
                                             onClick="submitTotp()" />
@@ -212,7 +217,8 @@ require_once 'includes/header.php';
                             </header>
                             <div class="totp-popup-content">
                                 <div class="form-group-inline">
-                                    <input type="text" id="totp-disable" name="totp-disable" placeholder="totp" />
+                                    <input type="text" id="totp-disable" name="totp-disable" autocomplete="one-time-code"
+                                        placeholder="totp" />
                                     <input type="button" value="<?= translate('disable', $i18n) ?>" id="disableTotpButton"
                                         onClick="submitDisableTotp()" />
                                 </div>

--- a/registration.php
+++ b/registration.php
@@ -354,27 +354,27 @@ if (isset($_POST['username'])) {
             <form action="registration.php" method="post">
                 <div class="form-group">
                     <label for="username"><?= translate('username', $i18n) ?>:</label>
-                    <input type="text" id="username" name="username" required>
+                    <input type="text" id="username" name="username" autocomplete="username" required>
                 </div>
                 <div class="form-group">
                     <label for="firstname"><?= translate('firstname', $i18n) ?>:</label>
-                    <input type="text" id="firstname" name="firstname">
+                    <input type="text" id="firstname" name="firstname" autocomplete="given-name">
                 </div>
                 <div class="form-group">
                     <label for="lastname"><?= translate('lastname', $i18n) ?>:</label>
-                    <input type="text" id="lastname" name="lastname">
+                    <input type="text" id="lastname" name="lastname" autocomplete="family-name">
                 </div>
                 <div class="form-group">
                     <label for="email"><?= translate('email', $i18n) ?>:</label>
-                    <input type="email" id="email" name="email" required>
+                    <input type="email" id="email" name="email" autocomplete="email" required>
                 </div>
                 <div class="form-group">
                     <label for="password"><?= translate('password', $i18n) ?>:</label>
-                    <input type="password" id="password" name="password" required>
+                    <input type="password" id="password" name="password" autocomplete="new-password" required>
                 </div>
                 <div class="form-group">
                     <label for="confirm_password"><?= translate('confirm_password', $i18n) ?>:</label>
-                    <input type="password" id="confirm_password" name="confirm_password" required>
+                    <input type="password" id="confirm_password" name="confirm_password" autocomplete="new-password" required>
                 </div>
                 <div class="form-group">
                     <label for="currency"><?= translate('main_currency', $i18n) ?>:</label>

--- a/settings.php
+++ b/settings.php
@@ -30,7 +30,8 @@ $userData['currency_symbol'] = $currencies[$main_currency]['symbol'];
         <div class="account-budget">
             <div class="form-group-inline">
                 <label for="budget"><?= $userData['currency_symbol'] ?></label>
-                <input type="number" id="budget" name="budget" value="<?= $userData['budget'] ?>" placeholder="Budget">
+                <input type="number" id="budget" name="budget" autocomplete="off" value="<?= $userData['budget'] ?>"
+                    placeholder="Budget">
                 <input type="submit" value="<?= translate('save', $i18n) ?>" id="saveBudget" onClick="saveBudget()" />
             </div>
             <div class="settings-notes">
@@ -65,11 +66,12 @@ $userData['currency_symbol'] = $currencies[$main_currency]['symbol'];
                 foreach ($household as $index => $member) {
                     ?>
                     <div class="form-group-inline" data-memberid="<?= $member['id'] ?>">
-                        <input type="text" name="member" value="<?= $member['name'] ?>" placeholder="Member">
+                        <input type="text" name="member" autocomplete="off" value="<?= $member['name'] ?>"
+                            placeholder="Member">
                         <?php
                         if ($index !== 0) {
                             ?>
-                            <input type="text" name="email" value="<?= $member['email'] ?? "" ?>"
+                            <input type="text" name="email" autocomplete="off" value="<?= $member['email'] ?? "" ?>"
                                 placeholder="<?= translate("email", $i18n) ?>">
                             <?php
                         }
@@ -369,10 +371,11 @@ $userData['currency_symbol'] = $currencies[$main_currency]['symbol'];
                         <label for="emailenabled" class="capitalize"><?= translate('enabled', $i18n) ?></label>
                     </div>
                     <div class="form-group-inline">
-                        <input type="text" name="smtpaddress" id="smtpaddress"
+                        <input type="text" name="smtpaddress" id="smtpaddress" autocomplete="off"
                             placeholder="<?= translate('smtp_address', $i18n) ?>"
                             value="<?= $notificationsEmail['smtp_address'] ?>" />
-                        <input type="text" name="smtpport" id="smtpport" placeholder="<?= translate('port', $i18n) ?>"
+                        <input type="text" name="smtpport" id="smtpport" autocomplete="off"
+                            placeholder="<?= translate('port', $i18n) ?>"
                             class="one-third" value="<?= $notificationsEmail['smtp_port'] ?>" />
                     </div>
                     <div class="form-group-inline">
@@ -395,23 +398,23 @@ $userData['currency_symbol'] = $currencies[$main_currency]['symbol'];
 
                     </div>
                     <div class="form-group-inline">
-                        <input type="text" name="smtpusername" id="smtpusername"
+                        <input type="text" name="smtpusername" id="smtpusername" autocomplete="off"
                             placeholder="<?= translate('smtp_username', $i18n) ?>"
                             value="<?= $notificationsEmail['smtp_username'] ?>" />
                     </div>
                     <div class="form-group-inline">
-                        <input type="password" name="smtppassword" id="smtppassword"
+                        <input type="password" name="smtppassword" id="smtppassword" autocomplete="off"
                             placeholder="<?= translate('smtp_password', $i18n) ?>"
                             value="<?= $notificationsEmail['smtp_password'] ?>" />
                     </div>
                     <div class="form-group-inline">
-                        <input type="text" name="fromemail" id="fromemail"
+                        <input type="text" name="fromemail" id="fromemail" autocomplete="off"
                             placeholder="<?= translate('from_email', $i18n) ?>"
                             value="<?= $notificationsEmail['from_email'] ?>" />
                     </div>
                     <label for="otheremails"><?= translate('send_to_other_emails', $i18n) ?></label>
                     <div class="form-group-inline">
-                        <input type="text" name="otheremails" id="otheremails"
+                        <input type="text" name="otheremails" id="otheremails" autocomplete="off"
                             placeholder="<?= translate('other_emails_placeholder', $i18n) ?>"
                             value="<?= $notificationsEmail['other_emails'] ?>" />
                     </div>
@@ -444,17 +447,17 @@ $userData['currency_symbol'] = $currencies[$main_currency]['symbol'];
                         <label for="discordenabled" class="capitalize"><?= translate('enabled', $i18n) ?></label>
                     </div>
                     <div class="form-group-inline">
-                        <input type="text" name="discordurl" id="discordurl"
+                        <input type="text" name="discordurl" id="discordurl" autocomplete="off"
                             placeholder="<?= translate('webhook_url', $i18n) ?>"
                             value="<?= $notificationsDiscord['webhook_url'] ?>" />
                     </div>
                     <div class="form-group-inline">
-                        <input type="text" name="discordbotusername" id="discordbotusername"
+                        <input type="text" name="discordbotusername" id="discordbotusername" autocomplete="off"
                             placeholder="<?= translate('discord_bot_username', $i18n) ?>"
                             value="<?= $notificationsDiscord['bot_username'] ?>" />
                     </div>
                     <div class="form-group-inline">
-                        <input type="text" name="discordbotavatar" id="discordbotavatar"
+                        <input type="text" name="discordbotavatar" id="discordbotavatar" autocomplete="off"
                             placeholder="<?= translate('discord_bot_avatar_url', $i18n) ?>"
                             value="<?= $notificationsDiscord['bot_avatar'] ?>" />
                     </div>
@@ -481,11 +484,12 @@ $userData['currency_symbol'] = $currencies[$main_currency]['symbol'];
                         <label for="gotifyenabled" class="capitalize"><?= translate('enabled', $i18n) ?></label>
                     </div>
                     <div class="form-group-inline">
-                        <input type="text" name="gotifyurl" id="gotifyurl" placeholder="<?= translate('url', $i18n) ?>"
+                        <input type="text" name="gotifyurl" id="gotifyurl" autocomplete="off"
+                            placeholder="<?= translate('url', $i18n) ?>"
                             value="<?= $notificationsGotify['url'] ?>" />
                     </div>
                     <div class="form-group-inline">
-                        <input type="text" name="gotifytoken" id="gotifytoken"
+                        <input type="text" name="gotifytoken" id="gotifytoken" autocomplete="off"
                             placeholder="<?= translate('token', $i18n) ?>"
                             value="<?= $notificationsGotify['token'] ?>" />
                     </div>
@@ -517,12 +521,12 @@ $userData['currency_symbol'] = $currencies[$main_currency]['symbol'];
                         <label for="pushoverenabled" class="capitalize"><?= translate('enabled', $i18n) ?></label>
                     </div>
                     <div class="form-group-inline">
-                        <input type="text" name="pushoveruserkey" id="pushoveruserkey"
+                        <input type="text" name="pushoveruserkey" id="pushoveruserkey" autocomplete="off"
                             placeholder="<?= translate('pushover_user_key', $i18n) ?>"
                             value="<?= $notificationsPushover['user_key'] ?>" />
                     </div>
                     <div class="form-group-inline">
-                        <input type="text" name="pushovertoken" id="pushovertoken"
+                        <input type="text" name="pushovertoken" id="pushovertoken" autocomplete="off"
                             placeholder="<?= translate('token', $i18n) ?>"
                             value="<?= $notificationsPushover['token'] ?>" />
                     </div>
@@ -550,12 +554,12 @@ $userData['currency_symbol'] = $currencies[$main_currency]['symbol'];
                         <label for="telegramenabled" class="capitalize"><?= translate('enabled', $i18n) ?></label>
                     </div>
                     <div class="form-group-inline">
-                        <input type="text" name="telegrambottoken" id="telegrambottoken"
+                        <input type="text" name="telegrambottoken" id="telegrambottoken" autocomplete="off"
                             placeholder="<?= translate('telegram_bot_token', $i18n) ?>"
                             value="<?= $notificationsTelegram['bot_token'] ? $notificationsTelegram['bot_token'] : "" ?>" />
                     </div>
                     <div class="form-group-inline">
-                        <input type="text" name="telegramchatid" id="telegramchatid"
+                        <input type="text" name="telegramchatid" id="telegramchatid" autocomplete="off"
                             placeholder="<?= translate('telegram_chat_id', $i18n) ?>"
                             value="<?= $notificationsTelegram['chat_id'] ?>" />
                     </div>
@@ -583,7 +587,7 @@ $userData['currency_symbol'] = $currencies[$main_currency]['symbol'];
             <label for="pushplusenabled" class="capitalize"><?= translate('enabled', $i18n) ?></label>
         </div>
         <div class="form-group-inline">
-            <input type="text" name="pushplustoken" id="pushplustoken"
+            <input type="text" name="pushplustoken" id="pushplustoken" autocomplete="off"
                 placeholder="<?= translate('pushplus_token', $i18n) ?>"
                 value="<?= $notificationsPushPlus['token'] ? $notificationsPushPlus['token'] : '' ?>" />
         </div>
@@ -609,11 +613,11 @@ $userData['currency_symbol'] = $currencies[$main_currency]['symbol'];
                         <label for="ntfyenabled" class="capitalize"><?= translate('enabled', $i18n) ?></label>
                     </div>
                     <div class="form-group-inline">
-                        <input type="text" name="ntfyhost" id="ntfyhost" placeholder="<?= translate('host', $i18n) ?>"
-                            value="<?= $notificationsNtfy['host'] ?>" />
+                        <input type="text" name="ntfyhost" id="ntfyhost" autocomplete="off"
+                            placeholder="<?= translate('host', $i18n) ?>" value="<?= $notificationsNtfy['host'] ?>" />
                     </div>
                     <div class="form-group-inline">
-                        <input type="text" name="ntfytopic" id="ntfytopic"
+                        <input type="text" name="ntfytopic" id="ntfytopic" autocomplete="off"
                             placeholder="<?= translate('topic', $i18n) ?>" value="<?= $notificationsNtfy['topic'] ?>" />
                     </div>
                     <div class="form-group-inline">
@@ -658,7 +662,7 @@ $userData['currency_symbol'] = $currencies[$main_currency]['symbol'];
                         </div>
                     </div>
                     <div class="form-group-inline">
-                        <input type="text" name="webhookurl" id="webhookurl"
+                        <input type="text" name="webhookurl" id="webhookurl" autocomplete="off"
                             placeholder="<?= translate('webhook_url', $i18n) ?>"
                             value="<?= $notificationsWebhook['url'] ?>" />
                     </div>
@@ -739,7 +743,8 @@ $userData['currency_symbol'] = $currencies[$main_currency]['symbol'];
                         ?>
                         <div class="form-group-inline" data-categoryid="<?= $category['id'] ?>">
                             <div class=" drag-icon"><i class="fa-solid fa-grip-vertical"></i></div>
-                            <input type="text" name="category" value="<?= $category['name'] ?>" placeholder="Category">
+                            <input type="text" name="category" autocomplete="off" value="<?= $category['name'] ?>"
+                                placeholder="Category">
                             <button class="image-button medium" onClick="editCategory(<?= $category['id'] ?>)" name="save"
                                 title="<?= translate('save_category', $i18n) ?>">
                                 <?php include "images/siteicons/svg/save.php"; ?>
@@ -827,9 +832,12 @@ $userData['currency_symbol'] = $currencies[$main_currency]['symbol'];
                     ?>
 
                     <div class="form-group-inline" data-currencyid="<?= $currency['id'] ?>">
-                        <input type="text" class="short" name="symbol" value="<?= $currency['symbol'] ?>" placeholder="$">
-                        <input type="text" name="currency" value="<?= $currency['name'] ?>" placeholder="Currency Name">
-                        <input type="text" name="code" value="<?= $currency['code'] ?>" placeholder="Currency Code"
+                        <input type="text" class="short" name="symbol" autocomplete="off"
+                            value="<?= $currency['symbol'] ?>" placeholder="$">
+                        <input type="text" name="currency" autocomplete="off"
+                            value="<?= $currency['name'] ?>" placeholder="Currency Name">
+                        <input type="text" name="code" autocomplete="off"
+                            value="<?= $currency['code'] ?>" placeholder="Currency Code"
                             <?= !$canDelete ? 'disabled' : '' ?>>
                         <button class="image-button medium" onClick="editCurrency(<?= $currency['id'] ?>)" name="save"
                             title="<?= translate('save_currency', $i18n) ?>">
@@ -910,7 +918,7 @@ $userData['currency_symbol'] = $currencies[$main_currency]['symbol'];
         </header>
         <div class="account-fixer">
             <div class="form-group">
-                <input type="text" name="fixer-key" id="fixerKey" value="<?= $apiKey ?>"
+                <input type="text" name="fixer-key" id="fixerKey" autocomplete="off" value="<?= $apiKey ?>"
                     placeholder="<?= translate('api_key', $i18n) ?>" <?= $demoMode ? 'disabled title="Not available on Demo Mode"' : '' ?>>
             </div>
             <div class="form-group">
@@ -979,11 +987,11 @@ $userData['currency_symbol'] = $currencies[$main_currency]['symbol'];
                 </select>
             </div>
             <div class="form-group-inline">
-                <input type="text" id="ai_api_key" name="ai_api_key"
+                <input type="text" id="ai_api_key" name="ai_api_key" autocomplete="off"
                     class="<?= (isset($aiSettings['type']) && $aiSettings['type'] == 'ollama') ? 'hidden' : '' ?>"
                     placeholder="<?= translate('api_key', $i18n) ?>"
                     value="<?= isset($aiSettings['api_key']) ? htmlspecialchars($aiSettings['api_key']) : '' ?>" />
-                <input type="text" id="ai_ollama_host" name="ai_ollama_host"
+                <input type="text" id="ai_ollama_host" name="ai_ollama_host" autocomplete="off"
                     class="<?= (!isset($aiSettings['type']) || $aiSettings['type'] != 'ollama') ? 'hidden' : '' ?>"
                     placeholder="<?= translate('host', $i18n) ?>"
                     value="<?= isset($aiSettings['url']) ? htmlspecialchars($aiSettings['url']) : '' ?>" />
@@ -1106,7 +1114,7 @@ $userData['currency_symbol'] = $currencies[$main_currency]['symbol'];
         <div>
             <form id="payments-form">
                 <div class="form-group-inline">
-                    <input type="text" name="paymentname" id="paymentname"
+                    <input type="text" name="paymentname" id="paymentname" autocomplete="off"
                         placeholder="<?= translate('payment_method_name', $i18n) ?>" onchange="setSearchButtonStatus()"
                         onkeypress="this.onchange();" onpaste="this.onchange();" oninput="this.onchange();" />
                     <label for="paymenticon" class="icon-preview">

--- a/subscriptions.php
+++ b/subscriptions.php
@@ -307,7 +307,8 @@ $headerClass = count($subscriptions) > 0 ? "main-actions" : "main-actions hidden
   <form action="endpoints/subscription/add.php" method="post" id="subs-form">
 
     <div class="form-group-inline">
-      <input type="text" id="name" name="name" placeholder="<?= translate('subscription_name', $i18n) ?>"
+      <input type="text" id="name" name="name" autocomplete="off"
+        placeholder="<?= translate('subscription_name', $i18n) ?>"
         onchange="setSearchButtonStatus()" onkeypress="this.onchange();" onpaste="this.onchange();"
         oninput="this.onchange();" required>
       <label for="logo" class="logo-preview">
@@ -331,7 +332,8 @@ $headerClass = count($subscriptions) > 0 ? "main-actions" : "main-actions hidden
     </div>
 
     <div class="form-group-inline">
-      <input type="number" step="0.01" id="price" name="price" placeholder="<?= translate('price', $i18n) ?>" required>
+      <input type="number" step="0.01" id="price" name="price" autocomplete="off"
+        placeholder="<?= translate('price', $i18n) ?>" required>
       <select id="currency" name="currency_id" placeholder="<?= translate('add_subscription', $i18n) ?>">
         <?php
         foreach ($currencies as $currency) {
@@ -386,7 +388,7 @@ $headerClass = count($subscriptions) > 0 ? "main-actions" : "main-actions hidden
         <div class="split50">
           <label for="start_date"><?= translate('start_date', $i18n) ?></label>
           <div class="date-wrapper">
-            <input type="date" id="start_date" name="start_date">
+            <input type="date" id="start_date" name="start_date" autocomplete="off">
           </div>
         </div>
         <button type="button" id="autofill-next-payment-button"
@@ -403,7 +405,7 @@ $headerClass = count($subscriptions) > 0 ? "main-actions" : "main-actions hidden
             </div>
           </label>
           <div class="date-wrapper">
-            <input type="date" id="next_payment" name="next_payment" required>
+            <input type="date" id="next_payment" name="next_payment" autocomplete="off" required>
           </div>
         </div>
       </div>
@@ -480,18 +482,18 @@ $headerClass = count($subscriptions) > 0 ? "main-actions" : "main-actions hidden
         <div class="split33 mobile-split-50">
           <label for="cancellation_date"><?= translate('cancellation_notification', $i18n) ?></label>
           <div class="date-wrapper">
-            <input type="date" id="cancellation_date" name="cancellation_date">
+            <input type="date" id="cancellation_date" name="cancellation_date" autocomplete="off">
           </div>
         </div>
       </div>
     </div>
 
     <div class="form-group">
-      <input type="text" id="url" name="url" placeholder="<?= translate('url', $i18n) ?>">
+      <input type="text" id="url" name="url" autocomplete="off" placeholder="<?= translate('url', $i18n) ?>">
     </div>
 
     <div class="form-group">
-      <input type="text" id="notes" name="notes" placeholder="<?= translate('notes', $i18n) ?>">
+      <input type="text" id="notes" name="notes" autocomplete="off" placeholder="<?= translate('notes', $i18n) ?>">
     </div>
 
     <div class="form-group">


### PR DESCRIPTION
This fix is aimed at improving the overall user experience:
- the browser can now suggest saving and updating the user's password;
- thus, it's easier to use auto-fill on the login screen (see screenshot);
- annoying suggestions will not appear when creating a new subscription;
- sensitive data is prevented from being saved in the settings and admin panel.

<img width="418" height="339" alt="image" src="https://github.com/user-attachments/assets/83ce9801-bfcd-4f9d-9f63-5784399fccab" />
