### PR TITLE
fix: use stable UID for iCal events to prevent duplicates

### DIFF
--- a/api/subscriptions/get_ical_feed.php
+++ b/api/subscriptions/get_ical_feed.php
@@ -172,7 +172,7 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" || $_SERVER["REQUEST_METHOD"] === "GET
         $subscription['trigger'] = ($subscription['notify_days_before'] == -1) ? $globalNotificationDays : ($subscription['notify_days_before'] ?: 1);
         $subscription['price'] = number_format($subscription['price'], 2);
 
-        $uid = uniqid();
+        $uid = 'wallos-subscription-' . $subscription['id'] . '@wallos';
         $summary = html_entity_decode($subscription['name'], ENT_QUOTES, 'UTF-8');
         $description = "Price: {$subscription['currency']}{$subscription['price']}\\nCategory: {$subscription['category']}\\nPayment Method: {$subscription['payment_method']}\\nPayer: {$subscription['payer_user']}\\nNotes: {$subscription['notes']}";
         $dtstart = (new DateTime($subscription['next_payment']))->format('Ymd');

--- a/endpoints/subscription/exportcalendar.php
+++ b/endpoints/subscription/exportcalendar.php
@@ -31,7 +31,7 @@ if ($subscription) {
     $subscription['price'] = number_format($subscription['price'], 2);
 
     // Create ICS from subscription information
-    $uid = uniqid();
+    $uid = 'wallos-subscription-' . $subscription['id'] . '@wallos';
     $summary = html_entity_decode($subscription['name'], ENT_QUOTES, 'UTF-8');
     $description = "Price: {$subscription['currency']}{$subscription['price']}\nCategory: {$subscription['category']}\nPayment Method: {$subscription['payment_method']}\nPayer: {$subscription['payer_user']}\n\nNotes: {$subscription['notes']}";
 


### PR DESCRIPTION
## Summary

Fixes iCal UID generation to use a stable, deterministic format based on subscription ID instead of randomly generated UIDs. This prevents calendar applications from creating duplicate events when the feed is refreshed.

## Problem

The current implementation uses `uniqid()` to generate UIDs:
```php
$uid = uniqid();
```

This creates a new UID every time the feed is generated, causing calendar apps (like Google Calendar) to treat each fetch as a new event instead of updating the existing one, resulting in duplicate events.

## Solution

Changed to a stable UID format based on subscription ID:
```php
$uid = 'wallos-subscription-' . $subscription['id'] . '@wallos';
```

This format:
- Is globally unique (includes subscription ID)
- Is persistent for the lifetime of the subscription
- Follows email-like convention commonly used in iCal UIDs
- Complies with RFC 5545 section 3.8.4.7 requirements

## RFC 5545 Reference

**Section 3.8.4.7 - Unique Identifier (UID):**
> The UID itself MUST be a globally unique identifier. The generator of the identifier MUST guarantee that the identifier is unique.

The UID must remain constant for the same calendar event across all instances and updates.

## Testing

Calendar applications will now:
- Update existing events when the feed is refreshed
- Not create duplicates for the same subscription
- Properly track changes to event details

## Files Changed

- `api/subscriptions/get_ical_feed.php` - Updated UID generation in feed endpoint
- `endpoints/subscription/exportcalendar.php` - Updated UID generation in export endpoint

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)