### PR TITLE
fix: unicode char in styles.css

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -133,7 +133,7 @@ header .logo .logo-image svg {
 }
 
 .dropbtn:after {
-  content: " ▼";
+  content: " \25BC";
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
In some cases, the server does not explicitly specify UTF-8 as the encoding for CSS, which results in garbled text.
