### PR TITLE
fix: retain first and last names on language change during registration

### DIFF
--- a/scripts/registration.js
+++ b/scripts/registration.js
@@ -17,6 +17,8 @@ function storeFormFieldValue(fieldId) {
 
 function storeFormFields() {
   storeFormFieldValue('username');
+  storeFormFieldValue('firstname');
+  storeFormFieldValue('lastname');
   storeFormFieldValue('email');
   storeFormFieldValue('password');
   storeFormFieldValue('confirm_password');
@@ -32,6 +34,8 @@ function restoreFormFieldValue(fieldId) {
 
 function restoreFormFields() {
   restoreFormFieldValue('username');
+  restoreFormFieldValue('firstname');
+  restoreFormFieldValue('lastname');
   restoreFormFieldValue('email');
   restoreFormFieldValue('password');
   restoreFormFieldValue('confirm_password');
@@ -40,6 +44,8 @@ function restoreFormFields() {
 
 function removeFromStorage() {
   localStorage.removeItem('username');
+  localStorage.removeItem('firstname');
+  localStorage.removeItem('lastname');
   localStorage.removeItem('email');
   localStorage.removeItem('password');
   localStorage.removeItem('confirm_password');


### PR DESCRIPTION
On changing language during registration, if the fields were already populated, the other fields' values are retained but first and last name are both cleared.

This change adds the `firstname` and `lastname` fields to those stored, restored and deleted.