### PR TITLE
Fix AI recommendation numbering after delete without page reload

### DIFF
--- a/scripts/dashboard.js
+++ b/scripts/dashboard.js
@@ -1,4 +1,13 @@
 document.addEventListener("DOMContentLoaded", function () {
+  function updateAiRecommendationNumbers() {
+    document.querySelectorAll(".ai-recommendation-item").forEach(function (item, index) {
+      const numberSpan = item.querySelector(".ai-recommendation-header h3 > span");
+      if (numberSpan) {
+        numberSpan.textContent = `${index + 1}. `;
+      }
+    });
+  }
+
   document.querySelectorAll(".ai-recommendation-item").forEach(function (item) {
     item.addEventListener("click", function () {
       item.classList.toggle("expanded");
@@ -25,6 +34,7 @@ document.addEventListener("DOMContentLoaded", function () {
         .then(data => {
           if (data.success) {
             item.remove();
+            updateAiRecommendationNumbers();
             showSuccessMessage(translate("success"));
           } else {
             showErrorMessage(data.message || translate("failed_delete_ai_recommendation"));


### PR DESCRIPTION
## Summary
Fixes a dashboard UI issue where AI recommendation numbering did not update immediately after deleting an item.

## Problem
When deleting an AI recommendation, the item was removed, but the remaining list numbers stayed stale until a full page reload.

## Changes
- Added client-side renumbering after successful delete.

## Testing
- Generate multiple AI recommendations.
- Deleted items from top, middle, and bottom of the list.
- Verified numbering updates instantly after each deletion without refreshing.