### PR TITLE
Clarify Docker Compose persistence and relative bind mount behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@
 
   <p>Wallos: Open-Source Personal Subscription Tracker</p>
 
-  [![Stars](https://img.shields.io/github/stars/ellite/Wallos?style=flat-square)](https://github.com/ellite/Wallos)
-  [![Docker](https://img.shields.io/docker/pulls/bellamy/wallos?style=flat-square)](https://hub.docker.com/r/bellamy/wallos)
-  [![GitHub contributors](https://img.shields.io/github/contributors/ellite/Wallos?style=flat-square)](https://github.com/ellite/Wallos/graphs/contributors)
-  [![GitHub Sponsors](https://img.shields.io/github/sponsors/ellite?style=flat-square)](https://github.com/sponsors/ellite)
-  [![Discord](https://img.shields.io/discord/1237073478910214235?logo=discord&style=flat-square)](https://discord.gg/anex9GUrPW)
-</div>
+[![Stars](https://img.shields.io/github/stars/ellite/Wallos?style=flat-square)](https://github.com/ellite/Wallos)
+[![Docker](https://img.shields.io/docker/pulls/bellamy/wallos?style=flat-square)](https://hub.docker.com/r/bellamy/wallos)
+[![GitHub contributors](https://img.shields.io/github/contributors/ellite/Wallos?style=flat-square)](https://github.com/ellite/Wallos/graphs/contributors)
+[![GitHub Sponsors](https://img.shields.io/github/sponsors/ellite?style=flat-square)](https://github.com/sponsors/ellite)
+[![Discord](https://img.shields.io/discord/1237073478910214235?logo=discord&style=flat-square)](https://discord.gg/anex9GUrPW)
 
+</div>
 
 ## Table of Contents
 
@@ -55,7 +55,7 @@ Wallos is a powerful, open-source, and self-hostable web application designed to
 - Logo Search: Wallos can search the web for the logo of your subscriptions if you don't have them available for upload.
 - Mobile view: Wallos on the go.
 - Statistics: Another perspective into your spendings.
-- Notifications:  Wallos supports multiple notification methods (email, discord, pushover, telegram, gotify and webhooks). Get notified about your upcoming payments.
+- Notifications: Wallos supports multiple notification methods (email, discord, pushover, telegram, gotify and webhooks). Get notified about your upcoming payments.
 - Multi Language support.
 - OIDC with OAuth
 - AI Recommendations with ChatGPT, Gemini or Local Ollama
@@ -67,7 +67,7 @@ The database is reset every 2 hours.
 To access the demo use the following credentials:
 
 ```python
-Username: demo  
+Username: demo
 Password: demo
 ```
 
@@ -81,16 +81,16 @@ See instructions to run Wallos below.
 
 - NGINX or APACHE websever running
 - PHP 8.3 with the following modules enabled:
-    - curl
-    - dom
-    - gd
-    - imagick
-    - intl
-    - openssl
-    - sqlite3
-    - zip
-    - mbstring
-    - fpm
+  - curl
+  - dom
+  - gd
+  - imagick
+  - intl
+  - openssl
+  - sqlite3
+  - zip
+  - mbstring
+  - fpm
 
 #### Docker
 
@@ -154,12 +154,16 @@ services:
       - "8282:80/tcp"
     environment:
       TZ: 'America/Toronto'
-    # Volumes store your data between container upgrades
+    # Use absolute host paths for persistence in long-lived deployments.
     volumes:
-      - './db:/var/www/html/db'
-      - './logos:/var/www/html/images/uploads/logos'
+      - '/srv/wallos/db:/var/www/html/db'
+      - '/srv/wallos/logos:/var/www/html/images/uploads/logos'
     restart: unless-stopped
 ```
+
+The SQLite database is stored in `/var/www/html/db` and uploaded logos/avatars are stored in `/var/www/html/images/uploads/logos` inside the container.
+
+If you prefer relative bind mounts such as `./db` and `./logos`, keep in mind that they are resolved on the Docker host from the Compose project directory. When you deploy through a stack manager, a remote context, or any workflow that changes the project directory between deployments, Wallos can start with a fresh empty data directory because Docker is mounting a different host path than before. Portainer stacks are one common example of this behavior. For long-lived deployments, absolute host paths like `/srv/wallos/db` and `/srv/wallos/logos` are safer.
 
 Disable healthcheck (optional, e.g., for Docker <25 or faster startup reporting):
 
@@ -173,8 +177,8 @@ services:
     environment:
       TZ: 'America/Toronto'
     volumes:
-      - './db:/var/www/html/db'
-      - './logos:/var/www/html/images/uploads/logos'
+      - '/srv/wallos/db:/var/www/html/db'
+      - '/srv/wallos/logos:/var/www/html/images/uploads/logos'
     restart: unless-stopped
     healthcheck:
       test: ["NONE"]
@@ -186,7 +190,7 @@ Just open the browser and open `ip:port` of the machine running wallos.
 On the first time you run wallos a user account must be created.  
 Go to settings and personalise your Avatar and add members of your household. While there add / remove any categories and currencies.  
 Get a free API Key from [Fixer](https://fixer.io/#pricing_plan) and add it in the settings.  
-If you want to trigger an Update of the exchange rates, change your main currency after adding the API Key, and then change it back to your preferred one.  
+If you want to trigger an Update of the exchange rates, change your main currency after adding the API Key, and then change it back to your preferred one.
 
 ## Screenshots
 
@@ -227,6 +231,7 @@ I welcome contributions from the community and look forward to working with you 
 ### Translations
 
 If you want to contribute with a translation of wallos:
+
 - Add your language code to `includes/i18n/languages.php` in the format `"en" => ["name" => "English", "dir" => "ltr"],`. Please use the original language name and not the english translation.
 - Create a copy of the file `includes/i18n/en.php` and rename it to the language code you used above. Example: pt.php for "pt" => ["name" => "Português", "dir" => "ltr"],.
 - Translate all the values on the language file to the new language. (Incomplete translations will not be accepted).
@@ -248,4 +253,3 @@ I strongly believe in the importance of open source software and the collaborati
 - The author: [henrique.pt](https://henrique.pt)
 - Wallos Landingpage: [wallosapp.com](https://wallosapp.com)
 - Join the conversation: [Discord Server](https://discord.gg/anex9GUrPW)
-

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,9 +5,13 @@ services:
     ports:
       - "8282:80/tcp"
     environment:
-      TZ: 'America/Toronto'
-    # Volumes store your data between container upgrades
+      TZ: "America/Toronto"
+    # Volumes store your data between container upgrades.
+    # Relative host paths are resolved from the Docker/Compose project directory.
+    # In stack managers or remote deployments (for example Portainer), prefer
+    # absolute host paths to avoid accidentally mounting a fresh empty db/ or
+    # logos/ directory on redeploy.
     volumes:
-      - './db:/var/www/html/db'
-      - './logos:/var/www/html/images/uploads/logos'
+      - "./db:/var/www/html/db"
+      - "./logos:/var/www/html/images/uploads/logos"
     restart: unless-stopped


### PR DESCRIPTION
## Summary

This updates the Docker Compose documentation to make persistence behavior clearer and safer for long-lived deployments.

## What changed

- Updated the Docker Compose example in the README to use absolute host path examples
- Documented where Wallos stores persistent data inside the container:
  - `/var/www/html/db`
  - `/var/www/html/images/uploads/logos`
- Added an explanation that relative bind mounts are resolved from the Compose project directory on the host
- Clarified that some deployment workflows can change that project directory between redeploys, which may cause Wallos to mount a new empty host path
- Mentioned Portainer as one example of this behavior
- Added a warning in the sample `docker-compose.yaml` comments to highlight the risk of relative bind mounts in stack-manager or remote deployment setups

## Why

Wallos already persists data correctly, but the previous Docker Compose example could be misleading because it used relative bind mounts without explaining their behavior.

When the Compose project directory changes between deployments, Docker can mount a different host directory than before. In that case, Wallos appears to start fresh even though the original data may still exist elsewhere on the host.

## Testing

Docs-only change. No runtime tests were required.

Closes #1008 