### PR TITLE
feat: Allow setting beginning of week as Sunday in calendar

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -96,6 +96,28 @@ $row = $result->fetchArray(SQLITE3_ASSOC);
 $code = $row['code'];
 
 $yearsToLoad = $calendarYear - $currentYear + 1;
+$weekStartsSunday = !empty($settings['week_starts_sunday']);
+$weekDays = [
+  ['key' => 'mon', 'offset' => 0],
+  ['key' => 'tue', 'offset' => 1],
+  ['key' => 'wed', 'offset' => 2],
+  ['key' => 'thu', 'offset' => 3],
+  ['key' => 'fri', 'offset' => 4],
+  ['key' => 'sat', 'offset' => 5],
+  ['key' => 'sun', 'offset' => 6],
+];
+
+if ($weekStartsSunday) {
+  $weekDays = [
+    ['key' => 'sun', 'offset' => 6],
+    ['key' => 'mon', 'offset' => 0],
+    ['key' => 'tue', 'offset' => 1],
+    ['key' => 'wed', 'offset' => 2],
+    ['key' => 'thu', 'offset' => 3],
+    ['key' => 'fri', 'offset' => 4],
+    ['key' => 'sat', 'offset' => 5],
+  ];
+}
 ?>
 
 <section class="contain">
@@ -150,7 +172,10 @@ $yearsToLoad = $calendarYear - $currentYear + 1;
     <?php
     $daysInMonth = cal_days_in_month(CAL_GREGORIAN, $calendarMonth, $calendarYear);
     $firstDay = mktime(0, 0, 0, $calendarMonth, 1, $calendarYear);
-    $firstDayOfWeek = date('N', $firstDay) - 1; // Adjusted to make Monday (1) the first day
+    $firstDayOfWeek = date('N', $firstDay) - 1;
+    if ($weekStartsSunday) {
+      $firstDayOfWeek = ($firstDayOfWeek + 1) % 7;
+    }
     $dayOfWeek = 0;
     $day = 1;
     $days = 1;
@@ -166,18 +191,14 @@ $yearsToLoad = $calendarYear - $currentYear + 1;
 
     <div class="calendar">
       <div class="calendar-header">
-        <div class="calendar-cell"><?= translate('mon', $i18n) ?></div>
-        <div class="calendar-cell"><?= translate('tue', $i18n) ?></div>
-        <div class="calendar-cell"><?= translate('wed', $i18n) ?></div>
-        <div class="calendar-cell"><?= translate('thu', $i18n) ?></div>
-        <div class="calendar-cell"><?= translate('fri', $i18n) ?></div>
-        <div class="calendar-cell"><?= translate('sat', $i18n) ?></div>
-        <div class="calendar-cell"><?= translate('sun', $i18n) ?></div>
+        <?php foreach ($weekDays as $weekDay) { ?>
+          <div class="calendar-cell"><?= translate($weekDay['key'], $i18n) ?></div>
+        <?php } ?>
       </div>
       <div class="calendar-body">
         <div class="week calendar-row">
           <?php
-          for ($i = 0; $i < $firstDayOfWeek; $i++) { // Fill empty cells if month doesn't start on Monday
+          for ($i = 0; $i < $firstDayOfWeek; $i++) {
             ?>
             <div class="calendar-cell empty">
               <div class="calendar-cell-header">

--- a/endpoints/admin/adduser.php
+++ b/endpoints/admin/adduser.php
@@ -222,8 +222,8 @@ if ($result) {
         $stmt->execute();
 
         // Add settings for that user
-        $query = "INSERT INTO settings (dark_theme, monthly_price, convert_currency, remove_background, color_theme, hide_disabled, user_id, disabled_to_bottom, show_original_price, mobile_nav) 
-                        VALUES (2, 0, 0, 0, 'blue', 0, :user_id, 0, 0, 0)";
+        $query = "INSERT INTO settings (dark_theme, monthly_price, convert_currency, remove_background, color_theme, hide_disabled, user_id, disabled_to_bottom, show_original_price, mobile_nav, week_starts_sunday) 
+                VALUES (2, 0, 0, 0, 'blue', 0, :user_id, 0, 0, 0, 0)";
         $stmt = $db->prepare($query);
         $stmt->bindValue(':user_id', $newUserId, SQLITE3_INTEGER);
         $stmt->execute();

--- a/endpoints/settings/week_starts_sunday.php
+++ b/endpoints/settings/week_starts_sunday.php
@@ -1,0 +1,32 @@
+<?php
+
+require_once '../../includes/connect_endpoint.php';
+require_once '../../includes/validate_endpoint.php';
+
+$postData = file_get_contents("php://input");
+$data = json_decode($postData, true);
+
+$week_starts_sunday = $data['value'];
+
+if (!isset($week_starts_sunday) || !is_bool($week_starts_sunday)) {
+    die(json_encode([
+        "success" => false,
+        "message" => translate("error", $i18n)
+    ]));
+}
+
+$stmt = $db->prepare('UPDATE settings SET week_starts_sunday = :week_starts_sunday WHERE user_id = :userId');
+$stmt->bindParam(':week_starts_sunday', $week_starts_sunday, SQLITE3_INTEGER);
+$stmt->bindParam(':userId', $userId, SQLITE3_INTEGER);
+
+if ($stmt->execute()) {
+    die(json_encode([
+        "success" => true,
+        "message" => translate("success", $i18n)
+    ]));
+} else {
+    die(json_encode([
+        "success" => false,
+        "message" => translate("error", $i18n)
+    ]));
+}

--- a/endpoints/settings/week_starts_sunday.php
+++ b/endpoints/settings/week_starts_sunday.php
@@ -6,14 +6,14 @@ require_once '../../includes/validate_endpoint.php';
 $postData = file_get_contents("php://input");
 $data = json_decode($postData, true);
 
-$week_starts_sunday = $data['value'];
-
-if (!isset($week_starts_sunday) || !is_bool($week_starts_sunday)) {
+if (!isset($data['value']) || !is_bool($data['value'])) {
     die(json_encode([
         "success" => false,
         "message" => translate("error", $i18n)
     ]));
 }
+
+$week_starts_sunday = $data['value'] ? 1 : 0;
 
 $stmt = $db->prepare('UPDATE settings SET week_starts_sunday = :week_starts_sunday WHERE user_id = :userId');
 $stmt->bindParam(':week_starts_sunday', $week_starts_sunday, SQLITE3_INTEGER);

--- a/includes/getsettings.php
+++ b/includes/getsettings.php
@@ -29,6 +29,7 @@ if ($settings !== false) {
     $settings['showOriginalPrice'] = $settings['show_original_price'] ? 'true': 'false';
     $settings['mobileNavigation'] = $settings['mobile_nav'] ? 'true': 'false';
     $settings['showSubscriptionProgress'] = $settings['show_subscription_progress'] ? 'true': 'false';
+    $settings['week_starts_sunday'] = isset($settings['week_starts_sunday']) ? $settings['week_starts_sunday'] : 0;
 }
 
 $query = "SELECT * FROM custom_colors WHERE user_id = :userId";

--- a/includes/i18n/en.php
+++ b/includes/i18n/en.php
@@ -279,6 +279,7 @@ $i18n = [
     "show_original_price" => "Also show original price when conversions or calculations are made",
     "experience" => "Experience",
     "show_subscription_progress" => "Show subscription progress",
+    "week_starts_on_sunday" => "Start week on Sunday in calendar",
     "disabled_subscriptions" => "Disabled Subscriptions",
     "hide_disabled_subscriptions" => "Hide disabled subscriptions",
     "show_disabled_subscriptions_at_the_bottom" => "Show disabled subscriptions at the bottom",

--- a/includes/oidc/oidc_create_user.php
+++ b/includes/oidc/oidc_create_user.php
@@ -171,8 +171,8 @@ if ($currency) {
 $userData['main_currency'] = $currency['id'];
 
 // Insert settings
-$stmt = $db->prepare("INSERT INTO settings (dark_theme, monthly_price, convert_currency, remove_background, color_theme, hide_disabled, user_id, disabled_to_bottom, show_original_price, mobile_nav) 
-                      VALUES (2, 0, 0, 0, 'blue', 0, :user_id, 0, 0, 0)");
+$stmt = $db->prepare("INSERT INTO settings (dark_theme, monthly_price, convert_currency, remove_background, color_theme, hide_disabled, user_id, disabled_to_bottom, show_original_price, mobile_nav, week_starts_sunday) 
+                      VALUES (2, 0, 0, 0, 'blue', 0, :user_id, 0, 0, 0, 0)");
 $stmt->bindValue(':user_id', $newUserId, SQLITE3_INTEGER);
 $stmt->execute();
 

--- a/migrations/000048.php
+++ b/migrations/000048.php
@@ -1,0 +1,10 @@
+<?php
+// This migration adds a "week_starts_sunday" column to the settings table and defaults it to false.
+
+$columnQuery = $db->query("SELECT * FROM pragma_table_info('settings') where name='week_starts_sunday'");
+$columnRequired = $columnQuery->fetchArray(SQLITE3_ASSOC) === false;
+
+if ($columnRequired) {
+    $db->exec("ALTER TABLE settings ADD COLUMN week_starts_sunday BOOLEAN DEFAULT 0");
+    $db->exec('UPDATE settings SET `week_starts_sunday` = 0');
+}

--- a/registration.php
+++ b/registration.php
@@ -287,8 +287,8 @@ if (isset($_POST['username'])) {
                 $stmt->execute();
 
                 // Add settings for that user
-                $query = "INSERT INTO settings (dark_theme, monthly_price, convert_currency, remove_background, color_theme, hide_disabled, user_id, disabled_to_bottom, show_original_price, mobile_nav) 
-                          VALUES (2, 0, 0, 0, 'blue', 0, :user_id, 0, 0, 0)";
+                $query = "INSERT INTO settings (dark_theme, monthly_price, convert_currency, remove_background, color_theme, hide_disabled, user_id, disabled_to_bottom, show_original_price, mobile_nav, week_starts_sunday) 
+                          VALUES (2, 0, 0, 0, 'blue', 0, :user_id, 0, 0, 0, 0)";
                 $stmt = $db->prepare($query);
                 $stmt->bindValue(':user_id', $userId, SQLITE3_INTEGER);
                 $stmt->execute();

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -1006,6 +1006,13 @@ function setShowSubscriptionProgress() {
   storeSettingsOnDB('subscription_progress', value);
 }
 
+function setWeekStartsSunday() {
+  const weekStartsSundayCheckbox = document.querySelector("#weekstartssunday");
+  const value = weekStartsSundayCheckbox.checked;
+
+  storeSettingsOnDB('week_starts_sunday', value);
+}
+
 function saveCategorySorting() {
   const categories = document.getElementById("categories");
   const categoryIds = Array.from(categories.children).map(c => c.dataset.categoryid);

--- a/settings.php
+++ b/settings.php
@@ -1443,6 +1443,13 @@ $userData['currency_symbol'] = $currencies[$main_currency]['symbol'];
                     <label for="showsubscriptionprogress"><?= translate('show_subscription_progress', $i18n) ?></label>
                 </div>
             </div>
+            <div>
+                <div class="form-group-inline">
+                    <input type="checkbox" id="weekstartssunday" name="weekstartssunday"
+                        onChange="setWeekStartsSunday()" <?= !empty($settings['week_starts_sunday']) ? 'checked' : '' ?>>
+                    <label for="weekstartssunday"><?= translate('week_starts_on_sunday', $i18n) ?></label>
+                </div>
+            </div>
             <h3><?= translate('disabled_subscriptions', $i18n) ?></h3>
             <div>
                 <div class="form-group-inline">


### PR DESCRIPTION
## Summary
Adds a user setting to start the calendar week on Sunday instead of Monday.

## Changes
- **Migration** (`migrations/000045.php`): Adds `week_starts_sunday` boolean column to the `settings` table, defaulting to `0` (Monday-first) for all existing users.
- **Settings UI** (`settings.php`): Adds a checkbox under *Display Settings → Experience* to toggle the preference.
- **Settings endpoint** (`endpoints/settings/week_starts_sunday.php`): Persists the preference to the database.
- **Calendar** (`calendar.php`): Rotates the weekday header and leading empty cells based on the saved preference.
- **i18n** (`includes/i18n/en.php`): Adds the `week_starts_on_sunday` translation key.
- **New user defaults** (`registration.php`, `endpoints/admin/adduser.php`, `includes/oidc/oidc_create_user.php`): Includes the new column in all `INSERT INTO settings` statements.
- **Settings loader** (`includes/getsettings.php`): Normalises the value with a safe fallback for rows that predate the migration.

## Behaviour
- Default is Monday-first (no change for existing users).
- When enabled, the calendar header shows Sun–Sat and the first-day offset is recalculated accordingly.

## Testing
- [ ] Run migrations on an existing database and verify `week_starts_sunday` column is added.
- [ ] Toggle the setting and confirm the calendar header and day-alignment update correctly for both Monday-first and Sunday-first.
- [ ] Register a new user and confirm the setting defaults to Monday-first.

Closes #1001 