### PR TITLE
feat: bulk actions for subscriptions (notify, delete, category, payment method)

### DIFF
--- a/endpoints/subscriptions/bulk_update.php
+++ b/endpoints/subscriptions/bulk_update.php
@@ -59,6 +59,46 @@ switch ($action) {
         $stmt->execute();
         break;
 
+    case 'set_category':
+        $value = intval($data['value'] ?? 0);
+        if ($value <= 0) {
+            echo json_encode(['success' => false, 'message' => 'Invalid category ID']);
+            exit;
+        }
+        $catCheck = $db->prepare("SELECT id FROM categories WHERE id = :id AND user_id = :userId");
+        $catCheck->bindValue(':id', $value, SQLITE3_INTEGER);
+        $catCheck->bindValue(':userId', $userId, SQLITE3_INTEGER);
+        if (!$catCheck->execute()->fetchArray(SQLITE3_ASSOC)) {
+            echo json_encode(['success' => false, 'message' => 'Invalid category']);
+            exit;
+        }
+        $sql = "UPDATE subscriptions SET category_id = :value WHERE id IN ($idList) AND user_id = :userId";
+        $stmt = $db->prepare($sql);
+        $stmt->bindParam(':value', $value, SQLITE3_INTEGER);
+        $stmt->bindParam(':userId', $userId, SQLITE3_INTEGER);
+        $stmt->execute();
+        break;
+
+    case 'set_payment_method':
+        $value = intval($data['value'] ?? 0);
+        if ($value <= 0) {
+            echo json_encode(['success' => false, 'message' => 'Invalid payment method ID']);
+            exit;
+        }
+        $pmCheck = $db->prepare("SELECT id FROM payment_methods WHERE id = :id AND user_id = :userId AND enabled = 1");
+        $pmCheck->bindValue(':id', $value, SQLITE3_INTEGER);
+        $pmCheck->bindValue(':userId', $userId, SQLITE3_INTEGER);
+        if (!$pmCheck->execute()->fetchArray(SQLITE3_ASSOC)) {
+            echo json_encode(['success' => false, 'message' => 'Invalid payment method']);
+            exit;
+        }
+        $sql = "UPDATE subscriptions SET payment_method_id = :value WHERE id IN ($idList) AND user_id = :userId";
+        $stmt = $db->prepare($sql);
+        $stmt->bindParam(':value', $value, SQLITE3_INTEGER);
+        $stmt->bindParam(':userId', $userId, SQLITE3_INTEGER);
+        $stmt->execute();
+        break;
+
     case 'delete':
         $sql = "DELETE FROM subscriptions WHERE id IN ($idList) AND user_id = :userId";
         $stmt = $db->prepare($sql);

--- a/endpoints/subscriptions/bulk_update.php
+++ b/endpoints/subscriptions/bulk_update.php
@@ -1,0 +1,75 @@
+<?php
+error_reporting(E_ERROR | E_PARSE);
+require_once '../../includes/connect_endpoint.php';
+require_once '../../includes/validate_endpoint.php';
+
+$data = json_decode(file_get_contents('php://input'), true);
+
+if (!isset($data['ids']) || !is_array($data['ids']) || empty($data['ids'])) {
+    echo json_encode(['success' => false, 'message' => 'No subscription IDs provided']);
+    exit;
+}
+
+if (!isset($data['action'])) {
+    echo json_encode(['success' => false, 'message' => 'No action specified']);
+    exit;
+}
+
+$ids = array_map('intval', $data['ids']);
+$action = $data['action'];
+$idList = implode(',', $ids);
+
+// Verify all IDs belong to the current user
+$verifyQuery = "SELECT COUNT(*) as cnt FROM subscriptions WHERE id IN ($idList) AND user_id = :userId";
+$stmt = $db->prepare($verifyQuery);
+$stmt->bindParam(':userId', $userId, SQLITE3_INTEGER);
+$result = $stmt->execute();
+$row = $result->fetchArray(SQLITE3_ASSOC);
+
+if ((int)$row['cnt'] !== count($ids)) {
+    echo json_encode(['success' => false, 'message' => 'Unauthorized']);
+    exit;
+}
+
+switch ($action) {
+    case 'enable_notify':
+        $sql = "UPDATE subscriptions SET notify = 1 WHERE id IN ($idList) AND user_id = :userId";
+        $stmt = $db->prepare($sql);
+        $stmt->bindParam(':userId', $userId, SQLITE3_INTEGER);
+        $stmt->execute();
+        break;
+
+    case 'disable_notify':
+        $sql = "UPDATE subscriptions SET notify = 0 WHERE id IN ($idList) AND user_id = :userId";
+        $stmt = $db->prepare($sql);
+        $stmt->bindParam(':userId', $userId, SQLITE3_INTEGER);
+        $stmt->execute();
+        break;
+
+    case 'set_notify_days':
+        $value = intval($data['value'] ?? -1);
+        if ($value < -1 || $value > 180) {
+            echo json_encode(['success' => false, 'message' => 'Invalid notify days value']);
+            exit;
+        }
+        $sql = "UPDATE subscriptions SET notify = 1, notify_days_before = :value WHERE id IN ($idList) AND user_id = :userId";
+        $stmt = $db->prepare($sql);
+        $stmt->bindParam(':value', $value, SQLITE3_INTEGER);
+        $stmt->bindParam(':userId', $userId, SQLITE3_INTEGER);
+        $stmt->execute();
+        break;
+
+    case 'delete':
+        $sql = "DELETE FROM subscriptions WHERE id IN ($idList) AND user_id = :userId";
+        $stmt = $db->prepare($sql);
+        $stmt->bindParam(':userId', $userId, SQLITE3_INTEGER);
+        $stmt->execute();
+        break;
+
+    default:
+        echo json_encode(['success' => false, 'message' => 'Invalid action']);
+        exit;
+}
+
+echo json_encode(['success' => true, 'count' => count($ids)]);
+$db->close();

--- a/includes/i18n/en.php
+++ b/includes/i18n/en.php
@@ -433,6 +433,16 @@ $i18n = [
     "over_budget_warning" => "You're over budget",
     // TOTP Page
     "insert_totp_code" => "Insert TOTP code",
+    // Bulk actions
+    "bulk_actions" => "Bulk actions",
+    "select_all" => "Select all",
+    "selected" => "selected",
+    "select_action" => "Select action...",
+    "enable_notifications" => "Enable notifications",
+    "disable_notifications" => "Disable notifications",
+    "set_notification_timing" => "Set notification timing",
+    "apply" => "Apply",
+    "cancel" => "Cancel",
 
 
 ];

--- a/includes/i18n/en.php
+++ b/includes/i18n/en.php
@@ -441,6 +441,8 @@ $i18n = [
     "enable_notifications" => "Enable notifications",
     "disable_notifications" => "Disable notifications",
     "set_notification_timing" => "Set notification timing",
+    "set_category" => "Set category",
+    "set_payment_method" => "Set payment method",
     "apply" => "Apply",
     "cancel" => "Cancel",
 

--- a/includes/i18n/zh_cn.php
+++ b/includes/i18n/zh_cn.php
@@ -454,6 +454,15 @@ $i18n = [
 
     // TOTP Page
     "insert_totp_code" => "请输入 TOTP 代码",
+    // 批量操作
+    "bulk_actions" => "批量操作",
+    "select_all" => "全选",
+    "selected" => "已选",
+    "select_action" => "选择操作...",
+    "enable_notifications" => "启用通知",
+    "disable_notifications" => "关闭通知",
+    "set_notification_timing" => "设置通知时间",
+    "apply" => "应用",
 
 ];
 

--- a/includes/i18n/zh_cn.php
+++ b/includes/i18n/zh_cn.php
@@ -462,6 +462,8 @@ $i18n = [
     "enable_notifications" => "启用通知",
     "disable_notifications" => "关闭通知",
     "set_notification_timing" => "设置通知时间",
+    "set_category" => "设置分类",
+    "set_payment_method" => "设置付款方式",
     "apply" => "应用",
 
 ];

--- a/includes/list_subscriptions.php
+++ b/includes/list_subscriptions.php
@@ -257,6 +257,10 @@ function printSubscriptions($subscriptions, $sort, $categories, $members, $i18n,
 
             ?>
 
+                <label class="subscription-bulk-checkbox" onClick="event.stopPropagation()">
+                <input type="checkbox" class="sub-select-checkbox" value="<?= $subscription['id'] ?>" onChange="updateBulkSelectedCount()">
+            </label>
+
             <div class="subscription<?= $subscriptionExtraClasses ?>"
                 onClick="toggleOpenSubscription(<?= $subscription['id'] ?>)" data-id="<?= $subscription['id'] ?>"
                 data-name="<?= $subscription['name'] ?>">

--- a/scripts/i18n/en.js
+++ b/scripts/i18n/en.js
@@ -60,4 +60,6 @@ let i18n = {
   confirm_bulk_delete: "Delete {count} subscription(s)? This cannot be undone.",
   bulk_action_success: "{count} subscription(s) updated",
   error_bulk_action: "Error performing bulk action",
+  set_category: "Set category",
+  set_payment_method: "Set payment method",
 }

--- a/scripts/i18n/en.js
+++ b/scripts/i18n/en.js
@@ -39,11 +39,25 @@ let i18n = {
   this_will_delete_all_data: "This will delete all your data and can't be undone. Continue?",
   success: "Success",
   copied_to_clipboard: "Copied to clipboard",
-  // Calendar 
+  // Calendar
   price: "Price",
   category: "Category",
   paid_by: "Paid by",
   payment_method: "Payment method",
   notes: "Notes",
   export: "Export",
+  // Bulk actions
+  bulk_actions: "Bulk actions",
+  select_all: "Select all",
+  selected: "selected",
+  select_action: "Select action...",
+  enable_notifications: "Enable notifications",
+  disable_notifications: "Disable notifications",
+  set_notification_timing: "Set notification timing",
+  apply: "Apply",
+  cancel: "Cancel",
+  no_subscriptions_selected: "No subscriptions selected",
+  confirm_bulk_delete: "Delete {count} subscription(s)? This cannot be undone.",
+  bulk_action_success: "{count} subscription(s) updated",
+  error_bulk_action: "Error performing bulk action",
 }

--- a/scripts/i18n/zh_cn.js
+++ b/scripts/i18n/zh_cn.js
@@ -60,4 +60,6 @@ let i18n = {
     confirm_bulk_delete: "确定删除 {count} 个订阅？此操作不可撤销。",
     bulk_action_success: "已更新 {count} 个订阅",
     error_bulk_action: "批量操作失败，请重试",
+    set_category: "设置分类",
+    set_payment_method: "设置付款方式",
 };

--- a/scripts/i18n/zh_cn.js
+++ b/scripts/i18n/zh_cn.js
@@ -46,4 +46,18 @@ let i18n = {
     payment_method: "支付方式",
     notes: "备注",
     export: "导出",
+    // 批量操作
+    bulk_actions: "批量操作",
+    select_all: "全选",
+    selected: "已选",
+    select_action: "选择操作...",
+    enable_notifications: "启用通知",
+    disable_notifications: "关闭通知",
+    set_notification_timing: "设置通知时间",
+    apply: "应用",
+    cancel: "取消",
+    no_subscriptions_selected: "请先选择订阅",
+    confirm_bulk_delete: "确定删除 {count} 个订阅？此操作不可撤销。",
+    bulk_action_success: "已更新 {count} 个订阅",
+    error_bulk_action: "批量操作失败，请重试",
 };

--- a/scripts/subscriptions.js
+++ b/scripts/subscriptions.js
@@ -1017,6 +1017,8 @@ function exitBulkMode() {
   document.getElementById('bulk-select-all').checked = false;
   document.getElementById('bulk-action-select').value = '';
   document.getElementById('bulk-notify-days-select').classList.add('hidden');
+  document.getElementById('bulk-category-select').classList.add('hidden');
+  document.getElementById('bulk-payment-select').classList.add('hidden');
   updateBulkSelectedCount();
 }
 
@@ -1037,6 +1039,8 @@ function bulkToggleSelectAll(checkbox) {
 function onBulkActionChange() {
   const action = document.getElementById('bulk-action-select').value;
   document.getElementById('bulk-notify-days-select').classList.toggle('hidden', action !== 'set_notify_days');
+  document.getElementById('bulk-category-select').classList.toggle('hidden', action !== 'set_category');
+  document.getElementById('bulk-payment-select').classList.toggle('hidden', action !== 'set_payment_method');
 }
 
 function applyBulkAction() {
@@ -1059,6 +1063,10 @@ function applyBulkAction() {
   const body = { ids, action };
   if (action === 'set_notify_days') {
     body.value = parseInt(document.getElementById('bulk-notify-days-select').value);
+  } else if (action === 'set_category') {
+    body.value = parseInt(document.getElementById('bulk-category-select').value);
+  } else if (action === 'set_payment_method') {
+    body.value = parseInt(document.getElementById('bulk-payment-select').value);
   }
 
   fetch('endpoints/subscriptions/bulk_update.php', {

--- a/scripts/subscriptions.js
+++ b/scripts/subscriptions.js
@@ -3,6 +3,15 @@ let scrollTopBeforeOpening = 0;
 const shouldScroll = window.innerWidth <= 768;
 
 function toggleOpenSubscription(subId) {
+  if (bulkModeActive) {
+    const container = document.querySelector('.subscription[data-id="' + subId + '"]').closest('.subscription-container');
+    const checkbox = container.querySelector('.sub-select-checkbox');
+    if (checkbox) {
+      checkbox.checked = !checkbox.checked;
+      updateBulkSelectedCount();
+    }
+    return;
+  }
   const subscriptionElement = document.querySelector('.subscription[data-id="' + subId + '"]');
   subscriptionElement.classList.toggle('is-open');
 }
@@ -1014,9 +1023,10 @@ function exitBulkMode() {
 function updateBulkSelectedCount() {
   const count = document.querySelectorAll('.sub-select-checkbox:checked').length;
   const total = document.querySelectorAll('.sub-select-checkbox').length;
-  document.getElementById('bulk-selected-count').textContent = count + ' ' + translate('selected');
+  document.getElementById('bulk-selected-count').textContent = translate('selected') + ' ' + count + ' / ' + total;
   document.getElementById('bulk-select-all').checked = total > 0 && count === total;
   document.getElementById('bulk-select-all').indeterminate = count > 0 && count < total;
+  document.getElementById('bulk-apply-btn').disabled = count === 0;
 }
 
 function bulkToggleSelectAll(checkbox) {

--- a/scripts/subscriptions.js
+++ b/scripts/subscriptions.js
@@ -979,3 +979,97 @@ window.addEventListener('load', () => {
     swipeHintAnimation();
   }
 });
+
+// ── Bulk Actions ──────────────────────────────────────────────────────────────
+
+let bulkModeActive = false;
+
+function toggleBulkMode() {
+  if (bulkModeActive) {
+    exitBulkMode();
+  } else {
+    enterBulkMode();
+  }
+}
+
+function enterBulkMode() {
+  bulkModeActive = true;
+  document.getElementById('subscriptions').classList.add('bulk-mode');
+  document.getElementById('bulk-toolbar').classList.add('visible');
+  document.getElementById('bulk-mode-btn').classList.add('active');
+}
+
+function exitBulkMode() {
+  bulkModeActive = false;
+  document.getElementById('subscriptions').classList.remove('bulk-mode');
+  document.getElementById('bulk-toolbar').classList.remove('visible');
+  document.getElementById('bulk-mode-btn').classList.remove('active');
+  document.querySelectorAll('.sub-select-checkbox').forEach(cb => { cb.checked = false; });
+  document.getElementById('bulk-select-all').checked = false;
+  document.getElementById('bulk-action-select').value = '';
+  document.getElementById('bulk-notify-days-select').classList.add('hidden');
+  updateBulkSelectedCount();
+}
+
+function updateBulkSelectedCount() {
+  const count = document.querySelectorAll('.sub-select-checkbox:checked').length;
+  const total = document.querySelectorAll('.sub-select-checkbox').length;
+  document.getElementById('bulk-selected-count').textContent = count + ' ' + translate('selected');
+  document.getElementById('bulk-select-all').checked = total > 0 && count === total;
+  document.getElementById('bulk-select-all').indeterminate = count > 0 && count < total;
+}
+
+function bulkToggleSelectAll(checkbox) {
+  document.querySelectorAll('.sub-select-checkbox').forEach(cb => { cb.checked = checkbox.checked; });
+  updateBulkSelectedCount();
+}
+
+function onBulkActionChange() {
+  const action = document.getElementById('bulk-action-select').value;
+  document.getElementById('bulk-notify-days-select').classList.toggle('hidden', action !== 'set_notify_days');
+}
+
+function applyBulkAction() {
+  const ids = Array.from(document.querySelectorAll('.sub-select-checkbox:checked')).map(cb => parseInt(cb.value));
+  if (ids.length === 0) {
+    showErrorMessage(translate('no_subscriptions_selected'));
+    return;
+  }
+
+  const action = document.getElementById('bulk-action-select').value;
+  if (!action) {
+    showErrorMessage(translate('select_action'));
+    return;
+  }
+
+  if (action === 'delete') {
+    if (!confirm(translate('confirm_bulk_delete').replace('{count}', ids.length))) return;
+  }
+
+  const body = { ids, action };
+  if (action === 'set_notify_days') {
+    body.value = parseInt(document.getElementById('bulk-notify-days-select').value);
+  }
+
+  fetch('endpoints/subscriptions/bulk_update.php', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRF-Token': window.csrfToken,
+    },
+    body: JSON.stringify(body),
+  })
+    .then(res => res.json())
+    .then(data => {
+      if (data.success) {
+        showSuccessMessage(translate('bulk_action_success').replace('{count}', data.count));
+        exitBulkMode();
+        fetchSubscriptions(null, null, 'bulk_update');
+      } else {
+        showErrorMessage(data.message || translate('error_bulk_action'));
+      }
+    })
+    .catch(() => {
+      showErrorMessage(translate('error_bulk_action'));
+    });
+}

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -670,7 +670,6 @@ button.mobile-action-renew {
   background-color: var(--box-background-color);
   box-shadow: var(--box-shadow);
   border-radius: 12px;
-  flex-wrap: wrap;
 }
 
 .bulk-toolbar.visible {
@@ -682,13 +681,18 @@ button.mobile-action-renew {
   align-items: center;
   gap: 10px;
   font-size: 15px;
+  flex-shrink: 0;
 }
 
 .bulk-toolbar-right {
   display: flex;
   align-items: center;
   gap: 8px;
-  flex-wrap: wrap;
+  flex-shrink: 0;
+}
+
+.bulk-toolbar select {
+  max-width: 180px;
 }
 
 .bulk-select-all-label {
@@ -778,8 +782,12 @@ button.mobile-action-renew {
   }
   .bulk-toolbar-right {
     width: 100%;
+    flex-wrap: wrap;
   }
-  .bulk-toolbar-right select,
+  .bulk-toolbar select {
+    max-width: none;
+    flex: 1;
+  }
   .bulk-toolbar-right .button {
     flex: 1;
   }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -763,6 +763,14 @@ button.mobile-action-renew {
   border-radius: 16px;
 }
 
+#subscriptions.bulk-mode .subscription {
+  cursor: pointer;
+}
+
+#subscriptions.bulk-mode .subscription:hover {
+  opacity: 0.85;
+}
+
 @media (max-width: 768px) {
   .bulk-toolbar {
     flex-direction: column;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -694,15 +694,29 @@ button.mobile-action-renew {
 .bulk-select-all-label {
   display: flex;
   align-items: center;
+  gap: 6px;
   cursor: pointer;
+}
+
+.bulk-select-all-text {
+  font-size: 14px;
+}
+
+.bulk-divider {
+  color: var(--border-color);
+  margin: 0 4px;
 }
 
 .bulk-select-all-label input[type="checkbox"],
 .subscription-bulk-checkbox input[type="checkbox"] {
-  width: 18px;
-  height: 18px;
+  opacity: 1 !important;
+  position: static !important;
+  width: 18px !important;
+  height: 18px !important;
   cursor: pointer;
   accent-color: var(--main-color);
+  margin: 0;
+  flex-shrink: 0;
 }
 
 .bulk-toolbar select {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -650,6 +650,129 @@ button.mobile-action-renew {
 
 }
 
+.subscription .notify-status {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  flex-shrink: 0;
+}
+
+/* ── Bulk Actions ─────────────────────────────────────────────────────────── */
+
+.bulk-toolbar {
+  display: none;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 10px 16px;
+  margin-bottom: 10px;
+  background-color: var(--box-background-color);
+  box-shadow: var(--box-shadow);
+  border-radius: 12px;
+  flex-wrap: wrap;
+}
+
+.bulk-toolbar.visible {
+  display: flex;
+}
+
+.bulk-toolbar-left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 15px;
+}
+
+.bulk-toolbar-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.bulk-select-all-label {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+}
+
+.bulk-select-all-label input[type="checkbox"],
+.subscription-bulk-checkbox input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+  accent-color: var(--main-color);
+}
+
+.bulk-toolbar select {
+  padding: 6px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+  background-color: var(--box-background-color);
+  color: var(--text-color);
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.bulk-toolbar select.hidden {
+  display: none;
+}
+
+#bulk-mode-btn.active {
+  background-color: var(--main-color);
+  color: #fff;
+  border-color: var(--main-color);
+}
+
+.subscription-bulk-checkbox {
+  display: none;
+  position: absolute;
+  left: 14px;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 10;
+  cursor: pointer;
+}
+
+#subscriptions.bulk-mode .subscription-bulk-checkbox {
+  display: flex;
+  align-items: center;
+}
+
+#subscriptions.bulk-mode .subscription-container {
+  padding-left: 44px;
+}
+
+#subscriptions.bulk-mode .subscription-container:has(.sub-select-checkbox:checked) {
+  outline: 2px solid var(--main-color);
+  border-radius: 16px;
+}
+
+@media (max-width: 768px) {
+  .bulk-toolbar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .bulk-toolbar-right {
+    width: 100%;
+  }
+  .bulk-toolbar-right select,
+  .bulk-toolbar-right .button {
+    flex: 1;
+  }
+}
+
+.subscription .notify-status .notify-on {
+  color: var(--main-color);
+  font-size: 15px;
+}
+
+.subscription .notify-status .notify-off {
+  color: #bbb;
+  font-size: 15px;
+}
+
 .subscription .price {
   flex-basis: 8%;
   justify-content: center;

--- a/subscriptions.php
+++ b/subscriptions.php
@@ -181,8 +181,41 @@ $headerClass = count($subscriptions) > 0 ? "main-actions" : "main-actions hidden
         </button>
         <?php include 'includes/sort_options.php'; ?>
       </div>
+
+      <button class="button secondary-button" id="bulk-mode-btn" title="<?= translate('bulk_actions', $i18n) ?>" onClick="toggleBulkMode()">
+        <i class="fa-solid fa-list-check"></i>
+      </button>
     </div>
   </header>
+
+  <div class="bulk-toolbar" id="bulk-toolbar">
+    <div class="bulk-toolbar-left">
+      <label class="bulk-select-all-label" title="<?= translate('select_all', $i18n) ?>">
+        <input type="checkbox" id="bulk-select-all" onChange="bulkToggleSelectAll(this)">
+      </label>
+      <span id="bulk-selected-count">0 <?= translate('selected', $i18n) ?></span>
+    </div>
+    <div class="bulk-toolbar-right">
+      <select id="bulk-action-select" onChange="onBulkActionChange()">
+        <option value=""><?= translate('select_action', $i18n) ?></option>
+        <option value="enable_notify"><?= translate('enable_notifications', $i18n) ?></option>
+        <option value="disable_notify"><?= translate('disable_notifications', $i18n) ?></option>
+        <option value="set_notify_days"><?= translate('set_notification_timing', $i18n) ?></option>
+        <option value="delete"><?= translate('delete', $i18n) ?></option>
+      </select>
+      <select id="bulk-notify-days-select" class="hidden">
+        <option value="-1"><?= translate('default_value_from_settings', $i18n) ?></option>
+        <option value="0"><?= translate('on_due_date', $i18n) ?></option>
+        <option value="1">1 <?= translate('day_before', $i18n) ?></option>
+        <?php for ($i = 2; $i <= 180; $i++): ?>
+          <option value="<?= $i ?>"><?= $i ?> <?= translate('days_before', $i18n) ?></option>
+        <?php endfor; ?>
+      </select>
+      <button class="button" id="bulk-apply-btn" onClick="applyBulkAction()"><?= translate('apply', $i18n) ?></button>
+      <button class="button secondary-button" onClick="exitBulkMode()"><?= translate('cancel', $i18n) ?></button>
+    </div>
+  </div>
+
   <div class="subscriptions" id="subscriptions">
     <?php
     $formatter = new IntlDateFormatter(

--- a/subscriptions.php
+++ b/subscriptions.php
@@ -203,7 +203,19 @@ $headerClass = count($subscriptions) > 0 ? "main-actions" : "main-actions hidden
         <option value="enable_notify"><?= translate('enable_notifications', $i18n) ?></option>
         <option value="disable_notify"><?= translate('disable_notifications', $i18n) ?></option>
         <option value="set_notify_days"><?= translate('set_notification_timing', $i18n) ?></option>
+        <option value="set_category"><?= translate('set_category', $i18n) ?></option>
+        <option value="set_payment_method"><?= translate('set_payment_method', $i18n) ?></option>
         <option value="delete"><?= translate('delete', $i18n) ?></option>
+      </select>
+      <select id="bulk-category-select" class="hidden">
+        <?php foreach ($categories as $cat): ?>
+          <option value="<?= $cat['id'] ?>"><?= htmlspecialchars($cat['name']) ?></option>
+        <?php endforeach; ?>
+      </select>
+      <select id="bulk-payment-select" class="hidden">
+        <?php foreach ($payment_methods as $pm): ?>
+          <option value="<?= $pm['id'] ?>"><?= htmlspecialchars($pm['name']) ?></option>
+        <?php endforeach; ?>
       </select>
       <select id="bulk-notify-days-select" class="hidden">
         <option value="-1"><?= translate('default_value_from_settings', $i18n) ?></option>

--- a/subscriptions.php
+++ b/subscriptions.php
@@ -192,7 +192,9 @@ $headerClass = count($subscriptions) > 0 ? "main-actions" : "main-actions hidden
     <div class="bulk-toolbar-left">
       <label class="bulk-select-all-label" title="<?= translate('select_all', $i18n) ?>">
         <input type="checkbox" id="bulk-select-all" onChange="bulkToggleSelectAll(this)">
+        <span class="bulk-select-all-text"><?= translate('select_all', $i18n) ?></span>
       </label>
+      <span class="bulk-divider">|</span>
       <span id="bulk-selected-count">0 <?= translate('selected', $i18n) ?></span>
     </div>
     <div class="bulk-toolbar-right">


### PR DESCRIPTION
## Summary

Adds a bulk actions toolbar to the subscriptions list, allowing users to select multiple subscriptions and apply an action in one click.

### Actions supported

- **Enable notifications** — set `notify = 1` for all selected
- **Disable notifications** — set `notify = 0` for all selected
- **Set notification timing** — set `notify_days_before` for all selected (includes "from settings" default option)
- **Set category** — reassign all selected to a chosen category
- **Set payment method** — reassign all selected to a chosen payment method
- **Delete** — delete all selected (with confirmation dialog)

### UX details

- Bulk mode is toggled via a button in the top action bar
- In bulk mode, clicking any subscription row toggles selection instead of opening the detail panel
- A counter shows "X / N selected"; the Apply button is disabled when nothing is selected
- Category and payment method selectors appear inline next to the action dropdown when their action is selected

### Backend

New endpoint `endpoints/subscriptions/bulk_update.php`:
- Validates that all submitted IDs belong to the current user before executing
- Uses parameterized queries for all UPDATE/DELETE operations
- Validates category/payment method ownership and enabled state before applying

## Test plan

- [ ] Enter bulk mode, select several subscriptions, enable/disable notifications
- [ ] Set notification timing to a specific day count; verify `notify_days_before` updated
- [ ] Bulk delete with confirmation; verify rows removed
- [ ] Set category: select subscriptions, choose a category, apply; verify category updated
- [ ] Set payment method: similar to above
- [ ] Verify Apply button is disabled when no subscriptions are selected
- [ ] Verify no cross-user data access (try with two accounts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)