### PR TITLE
feat(calendar): show subscription price in calendar cells

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -71,6 +71,39 @@ while ($row = $result->fetchArray(SQLITE3_ASSOC)) {
 }
 
 $currenciesInUse = array_unique($currenciesInUse);
+
+$calCurrencies = [];
+$stmtCur = $db->prepare("SELECT id, symbol FROM currencies WHERE user_id = :userId");
+$stmtCur->bindValue(':userId', $userId, SQLITE3_INTEGER);
+$resCur = $stmtCur->execute();
+while ($rowCur = $resCur->fetchArray(SQLITE3_ASSOC)) {
+  $calCurrencies[$rowCur['id']] = $rowCur['symbol'];
+}
+
+$calMembers = [];
+$stmtMem = $db->prepare("SELECT id, name FROM household WHERE user_id = :userId");
+$stmtMem->bindValue(':userId', $userId, SQLITE3_INTEGER);
+$resMem = $stmtMem->execute();
+while ($rowMem = $resMem->fetchArray(SQLITE3_ASSOC)) {
+  $calMembers[$rowMem['id']] = $rowMem['name'];
+}
+
+$calCategories = [];
+$stmtCat = $db->prepare("SELECT id, name FROM categories WHERE user_id = :userId");
+$stmtCat->bindValue(':userId', $userId, SQLITE3_INTEGER);
+$resCat = $stmtCat->execute();
+while ($rowCat = $resCat->fetchArray(SQLITE3_ASSOC)) {
+  $calCategories[$rowCat['id']] = $rowCat['name'];
+}
+
+$calPaymentMethods = [];
+$stmtPm = $db->prepare("SELECT id, name FROM payment_methods WHERE user_id = :userId AND enabled = 1");
+$stmtPm->bindValue(':userId', $userId, SQLITE3_INTEGER);
+$resPm = $stmtPm->execute();
+while ($rowPm = $resPm->fetchArray(SQLITE3_ASSOC)) {
+  $calPaymentMethods[$rowPm['id']] = $rowPm['name'];
+}
+
 $usesMultipleCurrencies = count($currenciesInUse) > 1;
 
 $showCantConverErrorMessage = false;
@@ -207,8 +240,9 @@ $yearsToLoad = $calendarYear - $currentYear + 1;
                       if (date('Y-m', $nextPaymentDate) == $calendarYear . '-' . str_pad($calendarMonth, 2, '0', STR_PAD_LEFT) && date('d', $nextPaymentDate) == $day) {
                         ?>
                         <div class="calendar-subscription-title" onClick="openSubscriptionModal(<?= $subscription['id'] ?>)">
-                          <?= htmlspecialchars($subscription['name']) ?>
+                          <span class="cal-name"><?= htmlspecialchars($subscription['name']) ?></span>
                         </div>
+                        <div class="cal-price" onClick="openSubscriptionModal(<?= $subscription['id'] ?>)"><?= ($calCurrencies[$subscription['currency_id']] ?? '') . number_format($subscription['price'], 2) ?></div>
                         <?php
                       }
                       continue;
@@ -253,8 +287,9 @@ $yearsToLoad = $calendarYear - $currentYear + 1;
                           }
                           ?>
                           <div class="calendar-subscription-title" onClick="openSubscriptionModal(<?= $subscription['id'] ?>)">
-                            <?= htmlspecialchars($subscription['name']) ?>
+                            <span class="cal-name"><?= htmlspecialchars($subscription['name']) ?></span>
                           </div>
+                          <div class="cal-price" onClick="openSubscriptionModal(<?= $subscription['id'] ?>)"><?= ($calCurrencies[$subscription['currency_id']] ?? '') . number_format($subscription['price'], 2) ?></div>
                           <?php
                         }
                       }
@@ -292,8 +327,9 @@ $yearsToLoad = $calendarYear - $currentYear + 1;
                     if (date('Y-m', $nextPaymentDate) == $calendarYear . '-' . str_pad($calendarMonth, 2, '0', STR_PAD_LEFT) && date('d', $nextPaymentDate) == $day) {
                       ?>
                       <div class="calendar-subscription-title" onClick="openSubscriptionModal(<?= $subscription['id'] ?>)">
-                        <?= htmlspecialchars($subscription['name']) ?>
+                        <span class="cal-name"><?= htmlspecialchars($subscription['name']) ?></span>
                       </div>
+                      <div class="cal-price" onClick="openSubscriptionModal(<?= $subscription['id'] ?>)"><?= ($calCurrencies[$subscription['currency_id']] ?? '') . number_format($subscription['price'], 2) ?></div>
                       <?php
                     }
                     continue;
@@ -338,8 +374,9 @@ $yearsToLoad = $calendarYear - $currentYear + 1;
                         }
                         ?>
                         <div class="calendar-subscription-title" onClick="openSubscriptionModal(<?= $subscription['id'] ?>)">
-                          <?= htmlspecialchars($subscription['name']) ?>
+                          <span class="cal-name"><?= htmlspecialchars($subscription['name']) ?></span>
                         </div>
+                        <div class="cal-price" onClick="openSubscriptionModal(<?= $subscription['id'] ?>)"><?= ($calCurrencies[$subscription['currency_id']] ?? '') . number_format($subscription['price'], 2) ?></div>
                         <?php
                       }
                     }
@@ -410,6 +447,23 @@ $yearsToLoad = $calendarYear - $currentYear + 1;
   </div>
 </div>
 
+<script>
+window.calendarSubscriptions = {};
+<?php foreach ($subscriptions as $sub): ?>
+window.calendarSubscriptions[<?= $sub['id'] ?>] = {
+  id: <?= $sub['id'] ?>,
+  name: <?= json_encode($sub['name']) ?>,
+  logo: <?= json_encode($sub['logo'] ?? '') ?>,
+  price: <?= json_encode(number_format($sub['price'], 2)) ?>,
+  currency: <?= json_encode($calCurrencies[$sub['currency_id']] ?? '') ?>,
+  category: <?= json_encode($calCategories[$sub['category_id']] ?? '') ?>,
+  payer_user: <?= json_encode($calMembers[$sub['payer_user_id']] ?? '') ?>,
+  payment_method: <?= json_encode($calPaymentMethods[$sub['payment_method_id']] ?? '') ?>,
+  notes: <?= json_encode($sub['notes'] ?? '') ?>,
+  auto_renew: <?= isset($sub['auto_renew']) ? (int)$sub['auto_renew'] : 'null' ?>
+};
+<?php endforeach; ?>
+</script>
 <script src="scripts/calendar.js?<?= $version ?>"></script>
 <?php
 require_once 'includes/footer.php';

--- a/scripts/calendar.js
+++ b/scripts/calendar.js
@@ -27,45 +27,52 @@ function closeSubscriptionModal() {
     modal.classList.remove('is-open');
 }
 
-function openSubscriptionModal(subscriptionId) {
+function renderSubscriptionModal(subscription) {
     const modal = document.getElementById('subscriptionModal');
     const modalContent = document.getElementById('subscriptionModalContent');
+    const html = `
+      <div class="modal-header">
+          <h3>${subscription.name}</h3>
+          <span class="fa-solid fa-xmark close-modal" onclick="closeSubscriptionModal()"></span>
+      </div>
+      <div class="modal-body">
+          ${subscription.logo ? `<div class="subscription-logo">
+          <img src="images/uploads/logos/${subscription.logo}" alt="${subscription.name}">
+          </div>` : ''}
+          <div class="subscription-info">
+          ${subscription.price ? `<p><strong>${translate('price')}:</strong> ${subscription.currency}${subscription.price}</p>` : ''}
+          ${subscription.category ? `<p><strong>${translate('category')}:</strong> ${subscription.category}</p>` : ''}
+          ${subscription.payer_user ? `<p><strong>${translate('paid_by')}:</strong> ${subscription.payer_user}</p>` : ''}
+          ${subscription.payment_method ? `<p><strong>${translate('payment_method')}:</strong> ${subscription.payment_method}</p>` : ''}
+          ${subscription.notes ? `<p><strong>${translate('notes')}:</strong> ${subscription.notes}</p>` : ''}
+          </div>
+      </div>
+      <div class="modal-footer">
+          <button class="button tiny" onclick="exportCalendar(${subscription.id})">${translate('export')}</button>
+      </div>`;
+    modalContent.innerHTML = html;
+    modal.classList.add('is-open');
+}
 
+function openSubscriptionModal(subscriptionId) {
+    if (window.calendarSubscriptions && window.calendarSubscriptions[subscriptionId]) {
+        renderSubscriptionModal(window.calendarSubscriptions[subscriptionId]);
+        return;
+    }
+
+    const modal = document.getElementById('subscriptionModal');
+    const modalContent = document.getElementById('subscriptionModalContent');
     modalContent.innerHTML = '';
 
     fetch('endpoints/subscription/getcalendar.php', {
         method: 'POST',
         body: JSON.stringify({id: subscriptionId}),
-        headers: {
-          'Content-Type': 'application/json'
-        }
+        headers: { 'Content-Type': 'application/json' }
       })
       .then(response => response.json())
       .then(data => {
         if (data.success && data.data) {
-          const subscription = data.data;
-          const html = `
-            <div class="modal-header">
-                <h3>${subscription.name}</h3>
-                <span class="fa-solid fa-xmark close-modal" onclick="closeSubscriptionModal()"></span>
-            </div>
-            <div class="modal-body">
-                ${subscription.logo ? `<div class="subscription-logo">
-                <img src="images/uploads/logos/${subscription.logo}" alt="${subscription.name}">
-                </div>` : ''}
-                <div class="subscription-info">
-                ${subscription.price ? `<p><strong>${translate('price')}:</strong> ${subscription.currency}${subscription.price}</p>` : ''}
-                ${subscription.category ? `<p><strong>${translate('category')}:</strong> ${subscription.category}</p>` : ''}
-                ${subscription.payer_user ? `<p><strong>${translate('paid_by')}:</strong> ${subscription.payer_user}</p>` : ''}
-                ${subscription.payment_method ? `<p><strong>${translate('payment_method')}:</strong> ${subscription.payment_method}</p>` : ''}
-                ${subscription.notes ? `<p><strong>${translate('notes')}:</strong> ${subscription.notes}</p>` : ''}
-                </div>
-            </div>
-            <div class="modal-footer">
-                <button class="button tiny" onclick="exportCalendar(${subscription.id})">${translate('export')}</button>
-            </div>`;
-          modalContent.innerHTML = html;
-          modal.classList.add('is-open');
+          renderSubscriptionModal(data.data);
         } else {
           console.error(data.message);
         }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -3151,3 +3151,43 @@ input[type="radio"]:checked+label::after {
 .dashboard-subscriptions-container::-webkit-scrollbar {
     display: none;
 }
+/* ── Calendar Price & Name ─────────────────────────────────────────────────── */
+
+.calendar .cal-name {
+  min-width: 0;
+}
+
+.calendar .cal-price {
+  font-size: 10px;
+  opacity: 0.7;
+  text-align: center;
+  cursor: pointer;
+  padding: 1px 4px 3px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (max-width: 480px) {
+  .calendar .calendar-subscription-title {
+    padding: 3px 3px;
+    gap: 3px;
+    font-size: 11px;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+  .calendar .cal-renewal-icon,
+  .calendar .cal-renewal-icon svg {
+    width: 11px !important;
+    height: 11px !important;
+  }
+  .calendar .cal-name {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    word-break: normal;
+    overflow-wrap: normal;
+  }
+}


### PR DESCRIPTION
## Summary

Each subscription entry in the calendar now shows its price (with currency symbol) below the subscription name, so users can see the cost at a glance without opening the detail popup.

### Performance improvement

Previously, clicking a calendar entry triggered a fetch to `endpoints/subscription/getcalendar.php` on every click. This PR preloads all visible subscription data into a `window.calendarSubscriptions` JS object on page render. The detail modal now opens instantly from local data, with a fetch fallback for subscriptions not found in the preloaded set.

### Technical notes

- Currency, member, category, and payment method lookups are resolved server-side at page load and embedded as a JS object, so no additional queries are needed on click.
- On mobile (≤480 px) the price and name are constrained to single-line display with text-overflow ellipsis.
- The modal HTML template is extracted into a shared `renderSubscriptionModal()` helper used by both the instant path and the fallback fetch path.

## Test plan

- [ ] Open calendar — verify each subscription shows price below name (e.g. `$9.99`)
- [ ] Verify currency symbol matches the subscription's currency
- [ ] Click a subscription — modal should open immediately (no loading delay)
- [ ] Verify modal still shows correct price, category, payer, payment method
- [ ] Check mobile viewport (≤480 px) — price and name should stay single-line

🤖 Generated with [Claude Code](https://claude.com/claude-code)