### PR TITLE
Harden OIDC state validation and session rotation

### DIFF
--- a/includes/checksession.php
+++ b/includes/checksession.php
@@ -14,6 +14,21 @@ if (isset($_GET['code']) && isset($_GET['state'])) {
     // This request is coming from the OIDC login flow
     $code = $_GET['code'];
     $state = $_GET['state'];
+    $expectedState = $_SESSION['oidc_state'] ?? null;
+
+    if (
+        !is_string($code) || $code === '' ||
+        !is_string($state) || $state === '' ||
+        !is_string($expectedState) || $expectedState === '' ||
+        !hash_equals($expectedState, $state)
+    ) {
+        unset($_SESSION['oidc_state']);
+        $db->close();
+        header("Location: login.php?error=oidc_invalid_state");
+        exit();
+    }
+
+    unset($_SESSION['oidc_state']);
 
     require_once 'includes/oidc/handle_oidc_callback.php';
 
@@ -82,6 +97,7 @@ if (isset($_GET['code']) && isset($_GET['state'])) {
                 $row = $result->fetchArray(SQLITE3_ASSOC);
 
                 if ($row != false) {
+                    session_regenerate_id(true);
                     $_SESSION['username'] = $username;
                     $_SESSION['token'] = $token;
                     $_SESSION['loggedin'] = true;

--- a/includes/oidc/oidc_login.php
+++ b/includes/oidc/oidc_login.php
@@ -9,6 +9,7 @@ $username = $userData['username'];
 $language = $userData['language'];
 $main_currency = $userData['main_currency'];
 
+session_regenerate_id(true);
 $_SESSION['username'] = $username;
 $_SESSION['loggedin'] = true;
 $_SESSION['main_currency'] = $main_currency;

--- a/login.php
+++ b/login.php
@@ -58,6 +58,7 @@ if ($adminRow['login_disabled'] == 1) {
         $username = $row['username'];
         $language = $row['language'];
 
+        session_regenerate_id(true);
         $_SESSION['username'] = $username;
         $_SESSION['loggedin'] = true;
         $_SESSION['main_currency'] = $main_currency;
@@ -229,6 +230,7 @@ if (isset($_POST['username']) && isset($_POST['password'])) {
                     ]);
                 }
 
+                session_regenerate_id(true);
                 $_SESSION['username'] = $username;
                 $_SESSION['loggedin'] = true;
                 $_SESSION['main_currency'] = $main_currency;
@@ -296,7 +298,7 @@ if (!$password_login_disabled) {
 }
 
 
-if (isset($_GET['error']) && $_GET['error'] == "oidc_user_not_found") {
+if (isset($_GET['error']) && in_array($_GET['error'], ["oidc_user_not_found", "oidc_invalid_state"], true)) {
     $loginFailed = true;
 }
 

--- a/totp.php
+++ b/totp.php
@@ -104,6 +104,7 @@ if (isset($_POST['one-time-code'])) {
         $result = $stmt->execute();
         $user = $result->fetchArray(SQLITE3_ASSOC);
 
+        session_regenerate_id(true);
         $_SESSION['username'] = $user['username'];
         $_SESSION['loggedin'] = true;
         $_SESSION['main_currency'] = $user['main_currency'];


### PR DESCRIPTION
the OIDC callback path generated and stored a state value before redirecting to the provider, but the callback handler accepted any returned state as long as code and state were present which means the state value was not actually binding the callback to the login session.

Now it validates the returned OIDC state against the value stored in the PHP session using hash_equals, rejects missing or mismatched state, and clears the stored state once it has been used.

While touching the auth flow, this also rotates the PHP session ID at the points where a session becomes authenticated: password login, disabled-login auto-login, TOTP completion, OIDC login, and persistent-cookie session restore. That prevents an existing anonymous session ID from being carried into an authenticated session.