### PR TITLE
change sort when sort != next_payment

### DIFF
--- a/subscriptions.php
+++ b/subscriptions.php
@@ -102,7 +102,7 @@ if ($settings['disabledToBottom'] === 'true') {
 }
 
 if ($sort != "next_payment") {
-  $orderByClauses[] = "next_payment ASC";
+  $orderByClauses[] = "name ASC";
 }
 
 $sql .= " ORDER BY " . implode(", ", $orderByClauses);


### PR DESCRIPTION
I just had my other team members try it out. If we follow the current logic and prioritize subscriptions with the shortest remaining time, the subscriptions jump around on the page when the remaining time changes, which feels very strange. I think we should use more prominent near-expiration reminders to ensure users notice the subscription, instead of constantly changing its position in the list, which is very unpredictable. If I extend a subscription, it might suddenly move from the top to the lower middle, and I have to search for it again, which is very inconvenient. I changed the sorting to "name" in the code myself. It works much better. If permitted, I can submit a code update request. Or please make the change in the next update.