### PR TITLE
[codex] fix logo search proxy handling

### DIFF
--- a/endpoints/logos/search.php
+++ b/endpoints/logos/search.php
@@ -9,11 +9,15 @@ if (isset($_GET['search'])) {
             ?: getenv('HTTPS_PROXY')
             ?: getenv('http_proxy')
             ?: getenv('HTTP_PROXY')
+            ?: getenv('all_proxy')
+            ?: getenv('ALL_PROXY')
             ?: null;
 
         if ($proxy) {
             curl_setopt($ch, CURLOPT_PROXY, $proxy);
+            return true;
         }
+        return false;
     }
 
 
@@ -36,14 +40,14 @@ if (isset($_GET['search'])) {
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
         curl_setopt($ch, CURLOPT_USERAGENT, 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36');
         
-        curl_setopt($ch, CURLOPT_PROXY, '');
-        curl_setopt($ch, CURLOPT_NOPROXY, '*');
-
         if (!empty($headers)) curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
-        
+
         curl_setopt($ch, CURLOPT_RESOLVE, ["{$host}:{$port}:{$ip}"]);
 
-        applyProxy($ch);
+        if (!applyProxy($ch)) {
+            curl_setopt($ch, CURLOPT_PROXY, '');
+            curl_setopt($ch, CURLOPT_NOPROXY, '*');
+        }
         $response = curl_exec($ch);
         unset($ch);
         return $response ?: null;


### PR DESCRIPTION
## Summary
- let the logo search endpoint keep using configured proxy environment variables
- only disable libcurl proxy handling when no proxy is configured
- include ALL_PROXY/all_proxy as fallback proxy variables

## Why
`curlGet()` set `CURLOPT_NOPROXY='*'` before `applyProxy()` ran, so logo search requests could bypass configured proxies and fail in deployments without direct access to DuckDuckGo or Brave.

Fixes #1073.

## Validation
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`
- `php -l endpoints/logos/search.php` not run: PHP is not installed in this local environment
