### PR TITLE
[codex] fix monthly cost currency fallback

### DIFF
--- a/api/subscriptions/get_monthly_cost.php
+++ b/api/subscriptions/get_monthly_cost.php
@@ -84,6 +84,7 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" || $_SERVER["REQUEST_METHOD"] === "GET
     $title = date('F Y', strtotime($year . '-' . $month . '-01'));
     $monthlyCost = 0;
     $notes = [];
+    $currencies = [];
 
     $sql = "SELECT * FROM subscriptions WHERE user_id = :userId AND inactive = 0";
     $stmt = $db->prepare($sql);
@@ -105,7 +106,6 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" || $_SERVER["REQUEST_METHOD"] === "GET
             $stmt = $db->prepare($sql);
             $stmt->bindValue(':userId', $userId);
             $result = $stmt->execute();
-            $currencies = [];
             while ($currency = $result->fetchArray(SQLITE3_ASSOC)) {
                 $currencies[$currency['id']] = $currency['rate'];
             }
@@ -149,7 +149,12 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" || $_SERVER["REQUEST_METHOD"] === "GET
         for ($date = $startDate; $date <= strtotime("+1 month", $startOfMonth); $date = strtotime($incrementString, $date)) {
             if (date('Y-m', $date) == $year . '-' . str_pad($month, 2, '0', STR_PAD_LEFT)) {
                 $price = $subscription['price'];
-                if ($userCurrencyId !== $subscription['currency_id']) {
+                if (
+                    $userCurrencyId !== $subscription['currency_id']
+                    && $canConvertCurrency
+                    && isset($currencies[$userCurrencyId], $currencies[$subscription['currency_id']])
+                    && (float)$currencies[$subscription['currency_id']] !== 0.0
+                ) {
                     $price *= $currencies[$userCurrencyId] / $currencies[$subscription['currency_id']];
                 }
                 $monthlyCost += $price;


### PR DESCRIPTION
## Summary

- initialize the currency-rate map before monthly-cost calculations
- only convert a subscription price when exchange rates are available and the source rate is non-zero
- avoid PHP warnings/fatal errors when the endpoint detects multiple currencies but cannot load usable rates

## Why

When subscriptions use multiple currencies and exchange rates are unavailable, the endpoint adds a warning note but still attempts to read `$currencies[...]` during price conversion. That can emit warning HTML before the JSON response and can also hit a division-by-zero fatal error, causing API clients such as Homepage to reject the response as invalid.

Fixes #1093

## Validation

- reviewed the affected conversion path in `api/subscriptions/get_monthly_cost.php`
- `git diff --cached --stat`

I could not run `php -l` in this local environment because `php` is not installed.
