### PR TITLE
ci: pin Ilshidur/action-discord@master to a full commit SHA

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -164,7 +164,7 @@ jobs:
             $(printf 'ghcr.io/ellite/wallos@sha256:%s ' *)
       - name: Send notification to Discord
         if: needs.release.outputs.release_created == 'true'
-        uses: Ilshidur/action-discord@master
+        uses: Ilshidur/action-discord@d2594079a10f1d6739ee50a2471f0ca57418b554 # v0.4.0 (pin @master to a full commit SHA)
         with:
           args: "A new release has been created: ${{ steps.meta.outputs.version }}"
         env:


### PR DESCRIPTION
Hi, and thank you for Wallos.

Small hardening suggestion for the release workflow. In `.github/workflows/build-release.yaml`, the "Send notification to Discord" step uses the third-party action `Ilshidur/action-discord@master`. `@master` is a mutable branch, so whatever code lives at that ref runs whenever the release job executes.

That job holds a few secrets:
- `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` (workflow-level `env`),
- the `GITHUB_TOKEN` with `packages: write` (used to log in to ghcr.io), and
- `DISCORD_WEBHOOK`.

If that upstream branch were ever repointed or compromised, the action code could read those secrets on the next release — the same class of risk as the `tj-actions/changed-files` incident. This PR pins the action to a full commit SHA (the current `master` head, which is release `v0.4.0`), which is consistent with how the other actions in this workflow are referenced. Behaviour is unchanged.

Happy to adjust the version/SHA or the comment style if you'd prefer.

For transparency: I used AI assistance to help identify this and draft the change; I verified every line against the live workflow myself.
