### PR TITLE
add OIDC_REQUIRE_EMAIL_VERIFIED environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ If `OIDC_ISSUER` is set, Wallos will fetch `/.well-known/openid-configuration` a
 | `OIDC_SCOPES` | `Scopes` |
 | `OIDC_AUTO_CREATE_USER` | `Create user automatically` |
 | `OIDC_DISABLE_PASSWORD_LOGIN` | `Disable password login` |
+| `OIDC_REQUIRE_EMAIL_VERIFIED` | `Require verified email for account linking` |
 
 ## API Documentation
 

--- a/admin.php
+++ b/admin.php
@@ -263,7 +263,8 @@ $loginDisabledAllowed = $userCount == 1 && $settings['registrations_open'] == 0;
             </div>
             <div class="form-group-inline">
                 <input type="checkbox" id="oidcRequireEmailVerified"
-                    <?= $oidcSettings['require_email_verified'] ? 'checked' : '' ?> />
+                    <?= $oidcSettings['require_email_verified'] ? 'checked' : '' ?>
+                    <?= oidc_input_attrs('require_email_verified', $oidcManagedFields) ?> />
                 <label for="oidcRequireEmailVerified"><?= translate('require_email_verified_linking', $i18n) ?></label>
             </div>
             <?php if (!empty($oidcManagedFields) || !empty($oidcNotes)): ?>

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,6 +22,7 @@ services:
       # OIDC_SCOPES: "openid email profile"
       # OIDC_AUTO_CREATE_USER: "true"
       # OIDC_DISABLE_PASSWORD_LOGIN: "false"
+      # OIDC_REQUIRE_EMAIL_VERIFIED: "true"
     # Volumes store your data between container upgrades
     volumes:
       - './db:/var/www/html/db'

--- a/includes/oidc_settings.php
+++ b/includes/oidc_settings.php
@@ -177,6 +177,16 @@ function wallos_get_effective_oidc_configuration($db)
         }
     }
 
+    if (wallos_has_oidc_env_value('OIDC_REQUIRE_EMAIL_VERIFIED')) {
+        $parsedValue = wallos_parse_oidc_boolean(wallos_get_oidc_env_value('OIDC_REQUIRE_EMAIL_VERIFIED'));
+        if ($parsedValue !== null) {
+            $settings['require_email_verified'] = $parsedValue;
+            $managedFields['require_email_verified'] = 'OIDC_REQUIRE_EMAIL_VERIFIED';
+        } else {
+            $notes[] = 'Ignoring invalid boolean value in OIDC_REQUIRE_EMAIL_VERIFIED.';
+        }
+    }
+
     if (wallos_has_oidc_env_value('OIDC_ISSUER')) {
         $issuer = (string) wallos_get_oidc_env_value('OIDC_ISSUER');
         $managedFields['issuer'] = 'OIDC_ISSUER';


### PR DESCRIPTION
By allowing this to be set via environment variable, we are one step closer to OIDC being available immediately on initial start-up.