### PR TITLE
feat: Colored folders to group subscriptions into pockets

### DIFF
--- a/endpoints/folders/folder.php
+++ b/endpoints/folders/folder.php
@@ -1,0 +1,171 @@
+<?php
+require_once '../../includes/connect_endpoint.php';
+require_once '../../includes/inputvalidation.php';
+require_once '../../includes/validate_endpoint.php';
+
+// Default palette cycled through when creating folders, so each new pocket
+// gets a distinct color before the user customizes it.
+const FOLDER_DEFAULT_COLORS = ['#657ff1', '#e0653a', '#31a952', '#a545c9', '#d9a919', '#3fa7ae', '#d94a83', '#8a6d4a'];
+
+function isValidHexColor($color)
+{
+    return preg_match('/^#[0-9a-fA-F]{6}$/', $color) === 1;
+}
+
+$action = $_POST['action'] ?? '';
+
+switch ($action) {
+    case "add":
+        handleAddFolder($db, $userId, $i18n);
+        break;
+    case "edit":
+        handleEditFolder($db, $userId, $i18n);
+        break;
+    case "delete":
+        handleDeleteFolder($db, $userId, $i18n);
+        break;
+    case "sort":
+        handleSortFolders($db, $userId, $i18n);
+        break;
+    default:
+        echo json_encode(["success" => false, "message" => translate('error', $i18n)]);
+        break;
+}
+
+function handleAddFolder($db, $userId, $i18n)
+{
+    $stmt = $db->prepare('SELECT MAX("order") as maxOrder, COUNT(*) as folderCount FROM folders WHERE user_id = :userId');
+    $stmt->bindParam(':userId', $userId, SQLITE3_INTEGER);
+    $result = $stmt->execute();
+    $row = $result->fetchArray(SQLITE3_ASSOC);
+    $maxOrder = $row['maxOrder'] ?? 0;
+    $folderCount = $row['folderCount'] ?? 0;
+
+    $order = $maxOrder + 1;
+    $folderName = "Folder";
+    $folderColor = FOLDER_DEFAULT_COLORS[$folderCount % count(FOLDER_DEFAULT_COLORS)];
+
+    $sqlInsert = 'INSERT INTO folders ("name", "color", "order", "user_id") VALUES (:name, :color, :order, :userId)';
+    $stmtInsert = $db->prepare($sqlInsert);
+    $stmtInsert->bindParam(':name', $folderName, SQLITE3_TEXT);
+    $stmtInsert->bindParam(':color', $folderColor, SQLITE3_TEXT);
+    $stmtInsert->bindParam(':order', $order, SQLITE3_INTEGER);
+    $stmtInsert->bindParam(':userId', $userId, SQLITE3_INTEGER);
+    $resultInsert = $stmtInsert->execute();
+
+    if ($resultInsert) {
+        $folderId = $db->lastInsertRowID();
+        $response = [
+            "success" => true,
+            "folderId" => $folderId,
+            "color" => $folderColor
+        ];
+        echo json_encode($response);
+    } else {
+        $response = [
+            "success" => false,
+            "message" => translate('failed_add_folder', $i18n)
+        ];
+        echo json_encode($response);
+    }
+}
+
+function handleEditFolder($db, $userId, $i18n)
+{
+    if (isset($_POST['folderId']) && $_POST['folderId'] != "" && isset($_POST['name']) && $_POST['name'] != "") {
+        $folderId = $_POST['folderId'];
+        $name = validate($_POST['name']);
+        $color = $_POST['color'] ?? '';
+        if (!isValidHexColor($color)) {
+            $color = '#657ff1';
+        }
+        $sql = "UPDATE folders SET name = :name, color = :color WHERE id = :folderId AND user_id = :userId";
+        $stmt = $db->prepare($sql);
+        $stmt->bindParam(':name', $name, SQLITE3_TEXT);
+        $stmt->bindParam(':color', $color, SQLITE3_TEXT);
+        $stmt->bindParam(':folderId', $folderId, SQLITE3_INTEGER);
+        $stmt->bindParam(':userId', $userId, SQLITE3_INTEGER);
+        $result = $stmt->execute();
+
+        if ($result) {
+            $response = [
+                "success" => true,
+                "message" => translate('folder_saved', $i18n)
+            ];
+            echo json_encode($response);
+        } else {
+            $response = [
+                "success" => false,
+                "message" => translate('failed_edit_folder', $i18n)
+            ];
+            echo json_encode($response);
+        }
+    } else {
+        $response = [
+            "success" => false,
+            "message" => translate('fill_all_fields', $i18n)
+        ];
+        echo json_encode($response);
+    }
+}
+
+function handleDeleteFolder($db, $userId, $i18n)
+{
+    if (isset($_POST['folderId']) && $_POST['folderId'] != "") {
+        $folderId = $_POST['folderId'];
+
+        // Folders are lightweight pockets: deleting one simply detaches its
+        // subscriptions instead of blocking the deletion.
+        $detach = $db->prepare("UPDATE subscriptions SET folder_id = NULL WHERE folder_id = :folderId AND user_id = :userId");
+        $detach->bindParam(':folderId', $folderId, SQLITE3_INTEGER);
+        $detach->bindParam(':userId', $userId, SQLITE3_INTEGER);
+        $detach->execute();
+
+        $sql = "DELETE FROM folders WHERE id = :folderId AND user_id = :userId";
+        $stmt = $db->prepare($sql);
+        $stmt->bindParam(':folderId', $folderId, SQLITE3_INTEGER);
+        $stmt->bindParam(':userId', $userId, SQLITE3_INTEGER);
+        $result = $stmt->execute();
+        if ($result) {
+            $response = [
+                "success" => true,
+                "message" => translate('folder_removed', $i18n)
+            ];
+            echo json_encode($response);
+        } else {
+            $response = [
+                "success" => false,
+                "message" => translate('failed_remove_folder', $i18n)
+            ];
+            echo json_encode($response);
+        }
+    } else {
+        $response = [
+            "success" => false,
+            "message" => translate('failed_remove_folder', $i18n)
+        ];
+        echo json_encode($response);
+    }
+}
+
+function handleSortFolders($db, $userId, $i18n)
+{
+    $folders = $_POST['folderIds'];
+    $order = 1;
+
+    foreach ($folders as $folderId) {
+        $sql = "UPDATE folders SET `order` = :order WHERE id = :folderId AND user_id = :userId";
+        $stmt = $db->prepare($sql);
+        $stmt->bindParam(':order', $order, SQLITE3_INTEGER);
+        $stmt->bindParam(':folderId', $folderId, SQLITE3_INTEGER);
+        $stmt->bindParam(':userId', $userId, SQLITE3_INTEGER);
+        $result = $stmt->execute();
+        $order++;
+    }
+
+    $response = [
+        "success" => true,
+        "message" => translate("sort_order_saved", $i18n)
+    ];
+    echo json_encode($response);
+}

--- a/endpoints/subscription/add.php
+++ b/endpoints/subscription/add.php
@@ -233,6 +233,19 @@ $startDate = $_POST["start_date"];
 $paymentMethodId = $_POST["payment_method_id"];
 $payerUserId = $_POST["payer_user_id"];
 $categoryId = $_POST['category_id'];
+$folderId = isset($_POST['folder_id']) && $_POST['folder_id'] != "" ? intval($_POST['folder_id']) : null;
+if ($folderId === 0) {
+    $folderId = null;
+}
+if ($folderId !== null) {
+    $folderCheck = $db->prepare("SELECT id FROM folders WHERE id = :id AND user_id = :userId");
+    $folderCheck->bindParam(':id', $folderId, SQLITE3_INTEGER);
+    $folderCheck->bindParam(':userId', $userId, SQLITE3_INTEGER);
+    $folderResult = $folderCheck->execute();
+    if (!$folderResult || !$folderResult->fetchArray()) {
+        $folderId = null;
+    }
+}
 $notes = validate($_POST["notes"]);
 $url = validate($_POST['url']);
 $logoUrl = validate($_POST['logo-url']);
@@ -311,12 +324,12 @@ if ($logo !== "" && $removeBackgroundEnabled) {
 if (!$isEdit) {
     $sql = "INSERT INTO subscriptions (
                         name, logo, price, currency_id, next_payment, cycle, frequency, notes,
-                        payment_method_id, payer_user_id, category_id, notify, inactive, url,
+                        payment_method_id, payer_user_id, category_id, folder_id, notify, inactive, url,
                         notify_days_before, user_id, cancellation_date, replacement_subscription_id,
                         auto_renew, start_date, logo_text_color, logo_variant
                     ) VALUES (
                         :name, :logo, :price, :currencyId, :nextPayment, :cycle, :frequency, :notes,
-                        :paymentMethodId, :payerUserId, :categoryId, :notify, :inactive, :url,
+                        :paymentMethodId, :payerUserId, :categoryId, :folderId, :notify, :inactive, :url,
                         :notifyDaysBefore, :userId, :cancellationDate, :replacement_subscription_id,
                         :autoRenew, :startDate, :logoTextColor, :logoVariant
                     )";
@@ -334,8 +347,9 @@ if (!$isEdit) {
                         notes = :notes, 
                         payment_method_id = :paymentMethodId,
                         payer_user_id = :payerUserId, 
-                        category_id = :categoryId, 
-                        notify = :notify, 
+                        category_id = :categoryId,
+                        folder_id = :folderId,
+                        notify = :notify,
                         inactive = :inactive, 
                         url = :url, 
                         notify_days_before = :notifyDaysBefore, 
@@ -367,6 +381,7 @@ $stmt->bindParam(':notes', $notes, SQLITE3_TEXT);
 $stmt->bindParam(':paymentMethodId', $paymentMethodId, SQLITE3_INTEGER);
 $stmt->bindParam(':payerUserId', $payerUserId, SQLITE3_INTEGER);
 $stmt->bindParam(':categoryId', $categoryId, SQLITE3_INTEGER);
+$stmt->bindParam(':folderId', $folderId, SQLITE3_INTEGER);
 $stmt->bindParam(':notify', $notify, SQLITE3_INTEGER);
 $stmt->bindParam(':inactive', $inactive, SQLITE3_INTEGER);
 $stmt->bindParam(':url', $url, SQLITE3_TEXT);

--- a/endpoints/subscription/clone.php
+++ b/endpoints/subscription/clone.php
@@ -19,7 +19,7 @@ if ($subscriptionToClone === false) {
     ]));
 }
 
-$query = "INSERT INTO subscriptions (name, logo, price, currency_id, next_payment, auto_renew, start_date, cycle, frequency, notes, payment_method_id, payer_user_id, category_id, notify, url, inactive, notify_days_before, user_id, cancellation_date, replacement_subscription_id) VALUES (:name, :logo, :price, :currency_id, :next_payment, :auto_renew, :start_date, :cycle, :frequency, :notes, :payment_method_id, :payer_user_id, :category_id, :notify, :url, :inactive, :notify_days_before, :user_id, :cancellation_date, :replacement_subscription_id)";
+$query = "INSERT INTO subscriptions (name, logo, price, currency_id, next_payment, auto_renew, start_date, cycle, frequency, notes, payment_method_id, payer_user_id, category_id, folder_id, notify, url, inactive, notify_days_before, user_id, cancellation_date, replacement_subscription_id) VALUES (:name, :logo, :price, :currency_id, :next_payment, :auto_renew, :start_date, :cycle, :frequency, :notes, :payment_method_id, :payer_user_id, :category_id, :folder_id, :notify, :url, :inactive, :notify_days_before, :user_id, :cancellation_date, :replacement_subscription_id)";
 $cloneStmt = $db->prepare($query);
 $cloneStmt->bindValue(':name', $subscriptionToClone['name'], SQLITE3_TEXT);
 $cloneStmt->bindValue(':logo', $subscriptionToClone['logo'], SQLITE3_TEXT);
@@ -34,6 +34,7 @@ $cloneStmt->bindValue(':notes', $subscriptionToClone['notes'], SQLITE3_TEXT);
 $cloneStmt->bindValue(':payment_method_id', $subscriptionToClone['payment_method_id'], SQLITE3_INTEGER);
 $cloneStmt->bindValue(':payer_user_id', $subscriptionToClone['payer_user_id'], SQLITE3_INTEGER);
 $cloneStmt->bindValue(':category_id', $subscriptionToClone['category_id'], SQLITE3_INTEGER);
+$cloneStmt->bindValue(':folder_id', $subscriptionToClone['folder_id'], SQLITE3_INTEGER);
 $cloneStmt->bindValue(':notify', $subscriptionToClone['notify'], SQLITE3_INTEGER);
 $cloneStmt->bindValue(':url', $subscriptionToClone['url'], SQLITE3_TEXT);
 $cloneStmt->bindValue(':inactive', $subscriptionToClone['inactive'], SQLITE3_INTEGER);

--- a/endpoints/subscription/get.php
+++ b/endpoints/subscription/get.php
@@ -29,6 +29,7 @@ if (isset($_SESSION['loggedin']) && $_SESSION['loggedin'] === true) {
             $subscriptionData['payment_method_id'] = $row['payment_method_id'];
             $subscriptionData['payer_user_id'] = $row['payer_user_id'];
             $subscriptionData['category_id'] = $row['category_id'];
+            $subscriptionData['folder_id'] = $row['folder_id'];
             $subscriptionData['notify'] = $row['notify'];
             $subscriptionData['inactive'] = $row['inactive'];
             $subscriptionData['url'] = htmlspecialchars_decode($row['url'] ?? "");

--- a/endpoints/subscriptions/get.php
+++ b/endpoints/subscriptions/get.php
@@ -53,6 +53,21 @@ if (isset($_SESSION['loggedin']) && $_SESSION['loggedin'] === true) {
     }
   }
 
+  if (isset($_GET['folders']) && $_GET['folders'] != "") {
+    $allFolders = explode(',', $_GET['folders']);
+    $placeholders = array_map(function ($idx) {
+      return ":folders{$idx}";
+    }, array_keys($allFolders));
+
+    $sql .= " AND (" . implode(' OR ', array_map(function ($placeholder) {
+      return "folder_id = {$placeholder}";
+    }, $placeholders)) . ")";
+
+    foreach ($allFolders as $idx => $folder) {
+      $params[":folders{$idx}"] = $folder;
+    }
+  }
+
   if (isset($_GET['payments']) && $_GET['payments'] !== "") {
     $allPayments = explode(',', $_GET['payments']);
     $placeholders = array_map(function ($idx) {
@@ -198,6 +213,7 @@ if (isset($_SESSION['loggedin']) && $_SESSION['loggedin'] === true) {
     $print[$id]['payment_method_name'] = $payment_methods[$paymentMethodId]['name'];
     $print[$id]['payment_method_id'] = $paymentMethodId;
     $print[$id]['category_id'] = $subscription['category_id'];
+    $print[$id]['folder_id'] = $subscription['folder_id'] ?? null;
     $print[$id]['payer_user_id'] = $subscription['payer_user_id'];
     $print[$id]['price'] = floatval($subscription['price']);
     $print[$id]['progress'] = getSubscriptionProgress($cycle, $frequency, $subscription['next_payment']);
@@ -243,7 +259,7 @@ if (isset($_SESSION['loggedin']) && $_SESSION['loggedin'] === true) {
   }
 
   if (isset($print)) {
-    printSubscriptions($print, $sort, $categories, $members, $i18n, $colorTheme, "../../", $settings['disabledToBottom'], $settings['mobileNavigation'], $settings['showSubscriptionProgress'], $currencies, $lang);
+    printSubscriptions($print, $sort, $categories, $folders, $members, $i18n, $colorTheme, "../../", $settings['disabledToBottom'], $settings['mobileNavigation'], $settings['showSubscriptionProgress'], $currencies, $lang);
   }
 
   if (count($subscriptions) == 0) {

--- a/includes/filters_menu.php
+++ b/includes/filters_menu.php
@@ -62,6 +62,34 @@
   }
   ?>
   <?php
+  if (!empty($folders)) {
+    ?>
+    <div class="filtermenu-submenu">
+      <div class="filter-title" onClick="toggleSubMenu('folder')"><?= translate("folder", $i18n) ?></div>
+      <div class="filtermenu-submenu-content" id="filter-folder">
+        <?php
+        foreach ($folders as $folder) {
+          $selectedClass = '';
+          if (isset($_GET['folder'])) {
+            $folderIds = explode(',', $_GET['folder']);
+            if (in_array($folder['id'], $folderIds)) {
+              $selectedClass = 'selected';
+            }
+          }
+          ?>
+          <div class="filter-item <?= $selectedClass ?>" data-folderid="<?= $folder['id'] ?>">
+            <span class="folder-filter-dot" style="background-color: <?= htmlspecialchars($folder['color']) ?>"></span>
+            <?= $folder['name'] ?>
+          </div>
+          <?php
+        }
+        ?>
+      </div>
+    </div>
+    <?php
+  }
+  ?>
+  <?php
   if (count($payment_methods) > 1) {
     ?>
     <div class="filtermenu-submenu">

--- a/includes/getdbkeys.php
+++ b/includes/getdbkeys.php
@@ -43,6 +43,17 @@
         $categories[$categoryId]['count'] = 0;
     }
 
+    $folders = array();
+    $query = "SELECT * FROM folders WHERE user_id = :userId ORDER BY `order` ASC";
+    $stmt = $db->prepare($query);
+    $stmt->bindValue(':userId', $userId, SQLITE3_INTEGER);
+    $result = $stmt->execute();
+    while ($row = $result->fetchArray(SQLITE3_ASSOC)) {
+        $folderId = $row['id'];
+        $folders[$folderId] = $row;
+        $folders[$folderId]['count'] = 0;
+    }
+
     $cycles = array();
     $query = "SELECT * FROM cycles";
     $result = $db->query($query);

--- a/includes/i18n/en.php
+++ b/includes/i18n/en.php
@@ -506,6 +506,7 @@ $i18n = [
     "failed_add_folder" => "Failed to add folder",
     "failed_edit_folder" => "Failed to save folder",
     "failed_remove_folder" => "Failed to remove folder",
+    "per_month" => "month",
     "folders_explanation" => "Group your subscriptions into colored folders, like pockets of payments, and filter them in one tap on the subscriptions page.",
 ];
 

--- a/includes/i18n/en.php
+++ b/includes/i18n/en.php
@@ -493,6 +493,20 @@ $i18n = [
     "google_search_info" => "Adds Google image results (via SerpAPI) as an additional source in the subscription logo search. Create a free SerpAPI account and paste your API key here.",
     "monthly_searches_used" => "Searches used this month",
     "monthly_requests_used" => "API requests used this month",
+
+    // Folders
+    "folders" => "Folders",
+    "folder" => "Folder",
+    "no_folder" => "No folder",
+    "folder_color" => "Folder color",
+    "save_folder" => "Save folder",
+    "delete_folder" => "Delete folder",
+    "folder_saved" => "Folder saved",
+    "folder_removed" => "Folder removed",
+    "failed_add_folder" => "Failed to add folder",
+    "failed_edit_folder" => "Failed to save folder",
+    "failed_remove_folder" => "Failed to remove folder",
+    "folders_explanation" => "Group your subscriptions into colored folders, like pockets of payments, and filter them in one tap on the subscriptions page.",
 ];
 
 

--- a/includes/i18n/fr.php
+++ b/includes/i18n/fr.php
@@ -493,6 +493,20 @@ $i18n = [
     "google_search_info" => "Ajoute les résultats d'images Google (via SerpAPI) comme source supplémentaire dans la recherche de logos. Créez un compte SerpAPI gratuit et collez ici votre clé API.",
     "monthly_searches_used" => "Recherches utilisées ce mois-ci",
     "monthly_requests_used" => "Requêtes API utilisées ce mois-ci",
+
+    // Folders
+    "folders" => "Dossiers",
+    "folder" => "Dossier",
+    "no_folder" => "Sans dossier",
+    "folder_color" => "Couleur du dossier",
+    "save_folder" => "Enregistrer le dossier",
+    "delete_folder" => "Supprimer le dossier",
+    "folder_saved" => "Dossier enregistré",
+    "folder_removed" => "Dossier supprimé",
+    "failed_add_folder" => "Échec de l'ajout du dossier",
+    "failed_edit_folder" => "Échec de l'enregistrement du dossier",
+    "failed_remove_folder" => "Échec de la suppression du dossier",
+    "folders_explanation" => "Regroupez vos abonnements dans des dossiers colorés, comme des poches de paiements, et filtrez-les en un clic sur la page des abonnements.",
 ];
 
 

--- a/includes/i18n/fr.php
+++ b/includes/i18n/fr.php
@@ -506,6 +506,7 @@ $i18n = [
     "failed_add_folder" => "Échec de l'ajout du dossier",
     "failed_edit_folder" => "Échec de l'enregistrement du dossier",
     "failed_remove_folder" => "Échec de la suppression du dossier",
+    "per_month" => "mois",
     "folders_explanation" => "Regroupez vos abonnements dans des dossiers colorés, comme des poches de paiements, et filtrez-les en un clic sur la page des abonnements.",
 ];
 

--- a/includes/list_subscriptions.php
+++ b/includes/list_subscriptions.php
@@ -159,7 +159,7 @@ function formatDate($date, $lang = 'en')
     return $formattedDate;
 }
 
-function printSubscriptions($subscriptions, $sort, $categories, $members, $i18n, $colorTheme, $imagePath, $disabledToBottom, $mobileNavigation, $showSubscriptionProgress, $currencies, $lang)
+function printSubscriptions($subscriptions, $sort, $categories, $folders, $members, $i18n, $colorTheme, $imagePath, $disabledToBottom, $mobileNavigation, $showSubscriptionProgress, $currencies, $lang)
 {
     if ($sort === "price") {
         usort($subscriptions, function ($a, $b) {
@@ -259,6 +259,13 @@ function printSubscriptions($subscriptions, $sort, $categories, $members, $i18n,
                 $subscriptionExtraClasses .= " manual";
             }
 
+            $folderStyle = "";
+            $folderId = $subscription['folder_id'] ?? null;
+            if ($folderId !== null && isset($folders[$folderId])) {
+                $subscriptionExtraClasses .= " in-folder";
+                $folderStyle = " style=\"--folder-color: " . htmlspecialchars($folders[$folderId]['color']) . "\" title=\"" . translate('folder', $i18n) . ": " . htmlspecialchars($folders[$folderId]['name']) . "\"";
+            }
+
             $hasLogo = false;
             if ($subscription['logo'] != "") {
                 $hasLogo = true;
@@ -266,7 +273,7 @@ function printSubscriptions($subscriptions, $sort, $categories, $members, $i18n,
 
             ?>
 
-            <div class="subscription<?= $subscriptionExtraClasses ?>"
+            <div class="subscription<?= $subscriptionExtraClasses ?>"<?= $folderStyle ?>
                 onClick="showSubscriptionDetails(event, <?= $subscription['id'] ?>)" data-id="<?= $subscription['id'] ?>"
                 data-name="<?= $subscription['name'] ?>">
                 <div class="subscription-main">

--- a/includes/subscription_details_popup.php
+++ b/includes/subscription_details_popup.php
@@ -52,6 +52,10 @@ require_once __DIR__ . '/getdbkeys.php';
       <dt><?= translate('category', $i18n) ?></dt>
       <dd id="details-category"></dd>
     </div>
+    <div class="details-item hide" id="details-folder-item">
+      <dt><?= translate('folder', $i18n) ?></dt>
+      <dd id="details-folder"></dd>
+    </div>
     <div class="details-item">
       <dt><?= translate('paid_by', $i18n) ?></dt>
       <dd id="details-payer"></dd>
@@ -85,6 +89,7 @@ require_once __DIR__ . '/getdbkeys.php';
 <?php
 $detailsLookups = [
   'categories' => new stdClass(),
+  'folders' => new stdClass(),
   'members' => new stdClass(),
   'paymentMethods' => new stdClass(),
   'currencies' => new stdClass(),
@@ -111,6 +116,12 @@ $detailsLookups = [
 ];
 foreach ($categories as $categoryId => $category) {
   $detailsLookups['categories']->{$categoryId} = $category['name'];
+}
+foreach ($folders as $folderId => $folder) {
+  $detailsLookups['folders']->{$folderId} = [
+    'name' => $folder['name'],
+    'color' => $folder['color'],
+  ];
 }
 foreach ($members as $memberId => $member) {
   $detailsLookups['members']->{$memberId} = $member['name'];

--- a/migrations/000054.php
+++ b/migrations/000054.php
@@ -1,0 +1,22 @@
+<?php
+
+// This migration adds support for colored folders ("pockets") that group subscriptions.
+// It creates the "folders" table and adds a "folder_id" column to the "subscriptions" table.
+
+$tableQuery = $db->query("SELECT name FROM sqlite_master WHERE type='table' AND name='folders'");
+if ($tableQuery->fetchArray(SQLITE3_ASSOC) === false) {
+    $db->exec('CREATE TABLE folders (
+        id INTEGER PRIMARY KEY,
+        name TEXT NOT NULL,
+        color TEXT DEFAULT "#657ff1",
+        `order` INTEGER DEFAULT 0,
+        user_id INTEGER DEFAULT 1
+    )');
+}
+
+$columnQuery = $db->query("SELECT * FROM pragma_table_info('subscriptions') WHERE name='folder_id'");
+if ($columnQuery->fetchArray(SQLITE3_ASSOC) === false) {
+    $db->exec('ALTER TABLE subscriptions ADD COLUMN folder_id INTEGER DEFAULT NULL');
+}
+
+?>

--- a/scripts/i18n/ar.js
+++ b/scripts/i18n/ar.js
@@ -50,4 +50,12 @@ let i18n = {
   notes: "ملاحظات",
   export: "تصدير",
   no_results_found: "لم يُعثر على نتائج",
+  // Folders
+  folder: "Folder",
+  folder_color: "Folder color",
+  save_folder: "Save folder",
+  delete_folder: "Delete folder",
+  failed_add_folder: "Failed to add folder",
+  failed_save_folder: "Failed to save folder",
+  failed_remove_folder: "Failed to remove folder",
 }

--- a/scripts/i18n/ca.js
+++ b/scripts/i18n/ca.js
@@ -50,4 +50,12 @@ let i18n = {
   invalid_budget_period: "Període de pressupost seleccionat no vàlid",
   invalid_budget_anchor_date: "La data d'ancoratge ha de ser una data vàlida",
   no_results_found: "No s'han trobat resultats",
+  // Folders
+  folder: "Folder",
+  folder_color: "Folder color",
+  save_folder: "Save folder",
+  delete_folder: "Delete folder",
+  failed_add_folder: "Failed to add folder",
+  failed_save_folder: "Failed to save folder",
+  failed_remove_folder: "Failed to remove folder",
 }

--- a/scripts/i18n/cs.js
+++ b/scripts/i18n/cs.js
@@ -50,4 +50,12 @@ let i18n = {
   invalid_budget_period: "Vybrané rozpočtové období je neplatné",
   invalid_budget_anchor_date: "Počáteční datum musí být platné datum",
   no_results_found: "Nebyly nalezeny žádné výsledky",
+  // Folders
+  folder: "Folder",
+  folder_color: "Folder color",
+  save_folder: "Save folder",
+  delete_folder: "Delete folder",
+  failed_add_folder: "Failed to add folder",
+  failed_save_folder: "Failed to save folder",
+  failed_remove_folder: "Failed to remove folder",
 }

--- a/scripts/i18n/da.js
+++ b/scripts/i18n/da.js
@@ -50,4 +50,12 @@ let i18n = {
   invalid_budget_period: "Ugyldig budgetperiode valgt",
   invalid_budget_anchor_date: "Startdatoen skal være en gyldig dato",
   no_results_found: "Ingen resultater fundet",
+  // Folders
+  folder: "Folder",
+  folder_color: "Folder color",
+  save_folder: "Save folder",
+  delete_folder: "Delete folder",
+  failed_add_folder: "Failed to add folder",
+  failed_save_folder: "Failed to save folder",
+  failed_remove_folder: "Failed to remove folder",
 }

--- a/scripts/i18n/de.js
+++ b/scripts/i18n/de.js
@@ -52,4 +52,12 @@ let i18n = {
   invalid_budget_period: "Ungültiger Budgetzeitraum ausgewählt",
   invalid_budget_anchor_date: "Das Ankerdatum muss ein gültiges Datum sein",
   no_results_found: "Keine Ergebnisse gefunden",
+  // Folders
+  folder: "Folder",
+  folder_color: "Folder color",
+  save_folder: "Save folder",
+  delete_folder: "Delete folder",
+  failed_add_folder: "Failed to add folder",
+  failed_save_folder: "Failed to save folder",
+  failed_remove_folder: "Failed to remove folder",
 }

--- a/scripts/i18n/el.js
+++ b/scripts/i18n/el.js
@@ -50,4 +50,12 @@ let i18n = {
   invalid_budget_period: "Επιλέχθηκε μη έγκυρη περίοδος προϋπολογισμού",
   invalid_budget_anchor_date: "Η ημερομηνία αναφοράς πρέπει να είναι έγκυρη ημερομηνία",
   no_results_found: "Δεν βρέθηκαν αποτελέσματα",
+  // Folders
+  folder: "Folder",
+  folder_color: "Folder color",
+  save_folder: "Save folder",
+  delete_folder: "Delete folder",
+  failed_add_folder: "Failed to add folder",
+  failed_save_folder: "Failed to save folder",
+  failed_remove_folder: "Failed to remove folder",
 }

--- a/scripts/i18n/en.js
+++ b/scripts/i18n/en.js
@@ -50,4 +50,12 @@ let i18n = {
   invalid_budget: "Budget must be a non-negative number",
   invalid_budget_period: "Invalid budget period selected",
   invalid_budget_anchor_date: "Anchor date must be a valid date",
+  // Folders
+  folder: "Folder",
+  folder_color: "Folder color",
+  save_folder: "Save folder",
+  delete_folder: "Delete folder",
+  failed_add_folder: "Failed to add folder",
+  failed_save_folder: "Failed to save folder",
+  failed_remove_folder: "Failed to remove folder",
 }

--- a/scripts/i18n/es.js
+++ b/scripts/i18n/es.js
@@ -50,4 +50,12 @@ let i18n = {
   invalid_budget_period: "Periodo de presupuesto seleccionado no válido",
   invalid_budget_anchor_date: "La fecha de referencia debe ser una fecha válida",
   no_results_found: "No se encontraron resultados",
+  // Folders
+  folder: "Folder",
+  folder_color: "Folder color",
+  save_folder: "Save folder",
+  delete_folder: "Delete folder",
+  failed_add_folder: "Failed to add folder",
+  failed_save_folder: "Failed to save folder",
+  failed_remove_folder: "Failed to remove folder",
 }

--- a/scripts/i18n/fr.js
+++ b/scripts/i18n/fr.js
@@ -50,4 +50,12 @@ let i18n = {
   invalid_budget_period: "Période de budget sélectionnée invalide",
   invalid_budget_anchor_date: "La date de référence doit être une date valide",
   no_results_found: "Aucun résultat trouvé",
+  // Folders
+  folder: "Dossier",
+  folder_color: "Couleur du dossier",
+  save_folder: "Enregistrer le dossier",
+  delete_folder: "Supprimer le dossier",
+  failed_add_folder: "Échec de l'ajout du dossier",
+  failed_save_folder: "Échec de l'enregistrement du dossier",
+  failed_remove_folder: "Échec de la suppression du dossier",
 };

--- a/scripts/i18n/hu.js
+++ b/scripts/i18n/hu.js
@@ -50,4 +50,12 @@ let i18n = {
   invalid_budget_period: "Érvénytelen költségvetési időszak lett kiválasztva",
   invalid_budget_anchor_date: "A kezdő dátumnak érvényes dátumnak kell lennie",
   no_results_found: "Nincs találat",
+  // Folders
+  folder: "Folder",
+  folder_color: "Folder color",
+  save_folder: "Save folder",
+  delete_folder: "Delete folder",
+  failed_add_folder: "Failed to add folder",
+  failed_save_folder: "Failed to save folder",
+  failed_remove_folder: "Failed to remove folder",
 }

--- a/scripts/i18n/id.js
+++ b/scripts/i18n/id.js
@@ -50,4 +50,12 @@ let i18n = {
   invalid_budget_period: "Periode anggaran yang dipilih tidak valid",
   invalid_budget_anchor_date: "Tanggal acuan harus berupa tanggal yang valid",
   no_results_found: "Tidak ada hasil ditemukan",
+  // Folders
+  folder: "Folder",
+  folder_color: "Folder color",
+  save_folder: "Save folder",
+  delete_folder: "Delete folder",
+  failed_add_folder: "Failed to add folder",
+  failed_save_folder: "Failed to save folder",
+  failed_remove_folder: "Failed to remove folder",
 }

--- a/scripts/i18n/it.js
+++ b/scripts/i18n/it.js
@@ -51,4 +51,12 @@ let i18n = {
   invalid_budget_period: "Periodo di budget selezionato non valido",
   invalid_budget_anchor_date: "La data di ancoraggio deve essere una data valida",
   no_results_found: "Nessun risultato trovato",
+  // Folders
+  folder: "Folder",
+  folder_color: "Folder color",
+  save_folder: "Save folder",
+  delete_folder: "Delete folder",
+  failed_add_folder: "Failed to add folder",
+  failed_save_folder: "Failed to save folder",
+  failed_remove_folder: "Failed to remove folder",
 }

--- a/scripts/i18n/ja.js
+++ b/scripts/i18n/ja.js
@@ -50,4 +50,12 @@ let i18n = {
   invalid_budget_period: "選択した予算期間が無効です",
   invalid_budget_anchor_date: "基準日は有効な日付である必要があります",
   no_results_found: "結果が見つかりません",
+  // Folders
+  folder: "Folder",
+  folder_color: "Folder color",
+  save_folder: "Save folder",
+  delete_folder: "Delete folder",
+  failed_add_folder: "Failed to add folder",
+  failed_save_folder: "Failed to save folder",
+  failed_remove_folder: "Failed to remove folder",
 }

--- a/scripts/i18n/ko.js
+++ b/scripts/i18n/ko.js
@@ -50,4 +50,12 @@ let i18n = {
   invalid_budget_period: "선택한 예산 기간이 유효하지 않습니다",
   invalid_budget_anchor_date: "기준 날짜는 유효한 날짜여야 합니다",
   no_results_found: "결과를 찾을 수 없습니다",
+  // Folders
+  folder: "Folder",
+  folder_color: "Folder color",
+  save_folder: "Save folder",
+  delete_folder: "Delete folder",
+  failed_add_folder: "Failed to add folder",
+  failed_save_folder: "Failed to save folder",
+  failed_remove_folder: "Failed to remove folder",
 };

--- a/scripts/i18n/nl.js
+++ b/scripts/i18n/nl.js
@@ -50,4 +50,12 @@ let i18n = {
   invalid_budget_period: "Ongeldige budgetperiode geselecteerd",
   invalid_budget_anchor_date: "Startdatum moet een geldige datum zijn",
   no_results_found: "Geen resultaten gevonden",
+  // Folders
+  folder: "Folder",
+  folder_color: "Folder color",
+  save_folder: "Save folder",
+  delete_folder: "Delete folder",
+  failed_add_folder: "Failed to add folder",
+  failed_save_folder: "Failed to save folder",
+  failed_remove_folder: "Failed to remove folder",
 }

--- a/scripts/i18n/pl.js
+++ b/scripts/i18n/pl.js
@@ -50,4 +50,12 @@ let i18n = {
   invalid_budget_period: "Wybrano nieprawidłowy okres budżetowy",
   invalid_budget_anchor_date: "Data odniesienia musi być prawidłową datą",
   no_results_found: "Nie znaleziono wyników",
+  // Folders
+  folder: "Folder",
+  folder_color: "Folder color",
+  save_folder: "Save folder",
+  delete_folder: "Delete folder",
+  failed_add_folder: "Failed to add folder",
+  failed_save_folder: "Failed to save folder",
+  failed_remove_folder: "Failed to remove folder",
 }

--- a/scripts/i18n/pt.js
+++ b/scripts/i18n/pt.js
@@ -50,4 +50,12 @@ let i18n = {
   invalid_budget_period: "Período de orçamento selecionado inválido",
   invalid_budget_anchor_date: "A data de referência deve ser uma data válida",
   no_results_found: "Nenhum resultado encontrado",
+  // Folders
+  folder: "Folder",
+  folder_color: "Folder color",
+  save_folder: "Save folder",
+  delete_folder: "Delete folder",
+  failed_add_folder: "Failed to add folder",
+  failed_save_folder: "Failed to save folder",
+  failed_remove_folder: "Failed to remove folder",
 };

--- a/scripts/i18n/pt_br.js
+++ b/scripts/i18n/pt_br.js
@@ -50,4 +50,12 @@ let i18n = {
   invalid_budget_period: "Período de orçamento selecionado inválido",
   invalid_budget_anchor_date: "A data de referência deve ser uma data válida",
   no_results_found: "Nenhum resultado encontrado",
+  // Folders
+  folder: "Folder",
+  folder_color: "Folder color",
+  save_folder: "Save folder",
+  delete_folder: "Delete folder",
+  failed_add_folder: "Failed to add folder",
+  failed_save_folder: "Failed to save folder",
+  failed_remove_folder: "Failed to remove folder",
 }

--- a/scripts/i18n/ro.js
+++ b/scripts/i18n/ro.js
@@ -50,4 +50,12 @@ let i18n = {
   invalid_budget_period: "Perioadă de buget selectată nevalidă",
   invalid_budget_anchor_date: "Data de referință trebuie să fie o dată validă",
   no_results_found: "Nu s-au găsit rezultate",
+  // Folders
+  folder: "Folder",
+  folder_color: "Folder color",
+  save_folder: "Save folder",
+  delete_folder: "Delete folder",
+  failed_add_folder: "Failed to add folder",
+  failed_save_folder: "Failed to save folder",
+  failed_remove_folder: "Failed to remove folder",
 }

--- a/scripts/i18n/ru.js
+++ b/scripts/i18n/ru.js
@@ -50,4 +50,12 @@ let i18n = {
   invalid_budget_period: "Выбран недопустимый бюджетный период",
   invalid_budget_anchor_date: "Дата отсчёта должна быть действительной датой",
   no_results_found: "Ничего не найдено",
+  // Folders
+  folder: "Folder",
+  folder_color: "Folder color",
+  save_folder: "Save folder",
+  delete_folder: "Delete folder",
+  failed_add_folder: "Failed to add folder",
+  failed_save_folder: "Failed to save folder",
+  failed_remove_folder: "Failed to remove folder",
 }

--- a/scripts/i18n/sl.js
+++ b/scripts/i18n/sl.js
@@ -50,4 +50,12 @@ let i18n = {
   invalid_budget_period: "Izbrano neveljavno proračunsko obdobje",
   invalid_budget_anchor_date: "Izhodiščni datum mora biti veljaven datum",
   no_results_found: "Ni najdenih rezultatov",
+  // Folders
+  folder: "Folder",
+  folder_color: "Folder color",
+  save_folder: "Save folder",
+  delete_folder: "Delete folder",
+  failed_add_folder: "Failed to add folder",
+  failed_save_folder: "Failed to save folder",
+  failed_remove_folder: "Failed to remove folder",
 }

--- a/scripts/i18n/sr.js
+++ b/scripts/i18n/sr.js
@@ -50,4 +50,12 @@ let i18n = {
   invalid_budget_period: "Изабран је неважећи период буџета",
   invalid_budget_anchor_date: "Референтни датум мора бити важећи датум",
   no_results_found: "Нема резултата",
+  // Folders
+  folder: "Folder",
+  folder_color: "Folder color",
+  save_folder: "Save folder",
+  delete_folder: "Delete folder",
+  failed_add_folder: "Failed to add folder",
+  failed_save_folder: "Failed to save folder",
+  failed_remove_folder: "Failed to remove folder",
 }

--- a/scripts/i18n/sr_lat.js
+++ b/scripts/i18n/sr_lat.js
@@ -50,4 +50,12 @@ let i18n = {
   invalid_budget_period: "Izabran je nevažeći period budžeta",
   invalid_budget_anchor_date: "Referentni datum mora biti važeći datum",
   no_results_found: "Nema rezultata",
+  // Folders
+  folder: "Folder",
+  folder_color: "Folder color",
+  save_folder: "Save folder",
+  delete_folder: "Delete folder",
+  failed_add_folder: "Failed to add folder",
+  failed_save_folder: "Failed to save folder",
+  failed_remove_folder: "Failed to remove folder",
 }

--- a/scripts/i18n/tr.js
+++ b/scripts/i18n/tr.js
@@ -50,6 +50,14 @@ let i18n = {
   invalid_budget_period: "Geçersiz bütçe dönemi seçildi",
   invalid_budget_anchor_date: "Referans tarih geçerli bir tarih olmalıdır",
   no_results_found: "Sonuç bulunamadı",
+  // Folders
+  folder: "Folder",
+  folder_color: "Folder color",
+  save_folder: "Save folder",
+  delete_folder: "Delete folder",
+  failed_add_folder: "Failed to add folder",
+  failed_save_folder: "Failed to save folder",
+  failed_remove_folder: "Failed to remove folder",
 }
 
 

--- a/scripts/i18n/uk.js
+++ b/scripts/i18n/uk.js
@@ -50,4 +50,12 @@ let i18n = {
   invalid_budget_period: "Вибрано недійсний бюджетний період",
   invalid_budget_anchor_date: "Дата відліку має бути дійсною датою",
   no_results_found: "Нічого не знайдено",
+  // Folders
+  folder: "Folder",
+  folder_color: "Folder color",
+  save_folder: "Save folder",
+  delete_folder: "Delete folder",
+  failed_add_folder: "Failed to add folder",
+  failed_save_folder: "Failed to save folder",
+  failed_remove_folder: "Failed to remove folder",
 }

--- a/scripts/i18n/vi.js
+++ b/scripts/i18n/vi.js
@@ -50,4 +50,12 @@ let i18n = {
   invalid_budget_period: "Kỳ ngân sách đã chọn không hợp lệ",
   invalid_budget_anchor_date: "Ngày mốc phải là ngày hợp lệ",
   no_results_found: "Không tìm thấy kết quả",
+  // Folders
+  folder: "Folder",
+  folder_color: "Folder color",
+  save_folder: "Save folder",
+  delete_folder: "Delete folder",
+  failed_add_folder: "Failed to add folder",
+  failed_save_folder: "Failed to save folder",
+  failed_remove_folder: "Failed to remove folder",
 }

--- a/scripts/i18n/zh_cn.js
+++ b/scripts/i18n/zh_cn.js
@@ -50,4 +50,12 @@ let i18n = {
   invalid_budget_period: "所选预算周期无效",
   invalid_budget_anchor_date: "起始日期必须是有效日期",
   no_results_found: "未找到结果",
+  // Folders
+  folder: "Folder",
+  folder_color: "Folder color",
+  save_folder: "Save folder",
+  delete_folder: "Delete folder",
+  failed_add_folder: "Failed to add folder",
+  failed_save_folder: "Failed to save folder",
+  failed_remove_folder: "Failed to remove folder",
 };

--- a/scripts/i18n/zh_tw.js
+++ b/scripts/i18n/zh_tw.js
@@ -50,4 +50,12 @@ let i18n = {
   invalid_budget_period: "所選預算週期無效",
   invalid_budget_anchor_date: "起始日期必須是有效日期",
   no_results_found: "找不到結果",
+  // Folders
+  folder: "Folder",
+  folder_color: "Folder color",
+  save_folder: "Save folder",
+  delete_folder: "Delete folder",
+  failed_add_folder: "Failed to add folder",
+  failed_save_folder: "Failed to save folder",
+  failed_remove_folder: "Failed to remove folder",
 };

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -420,6 +420,175 @@ function editCategory(categoryId) {
 }
 
 
+function addFolderButton() {
+  const addButton = document.getElementById("addFolder");
+  addButton.disabled = true;
+
+  fetch('endpoints/folders/folder.php', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'X-CSRF-Token': window.csrfToken,
+    },
+    body: new URLSearchParams({action: 'add'}),
+  })
+    .then(response => {
+      if (!response.ok) {
+        showErrorMessage(translate('failed_add_folder'));
+        throw new Error(translate('network_response_error'));
+      }
+      return response.json();
+    })
+    .then(responseData => {
+      if (responseData.success) {
+        const newFolderId = responseData.folderId;
+        const container = document.getElementById("folders");
+
+        const row = document.createElement("div");
+        row.className = "form-group-inline";
+        row.dataset.folderid = newFolderId;
+
+        const dragIcon = document.createElement("div");
+        dragIcon.className = "drag-icon";
+        dragIcon.innerHTML = '<i class="fa-solid fa-grip-vertical"></i>';
+
+        const colorInput = document.createElement("input");
+        colorInput.type = "color";
+        colorInput.name = "folder-color";
+        colorInput.className = "folder-color-picker";
+        colorInput.value = responseData.color;
+        colorInput.title = translate('folder_color');
+
+        const input = document.createElement("input");
+        input.type = "text";
+        input.placeholder = translate('folder');
+        input.name = "folder";
+        input.value = translate('folder');
+
+        const editLink = document.createElement("button");
+        editLink.className = "image-button medium";
+        editLink.name = "save";
+        editLink.onclick = function () {
+          editFolder(newFolderId);
+        };
+        editLink.innerHTML = saveIconContent;
+        editLink.title = translate('save_folder');
+
+        const deleteLink = document.createElement("button");
+        deleteLink.className = "image-button medium";
+        deleteLink.name = "delete";
+        deleteLink.onclick = function () {
+          removeFolder(newFolderId);
+        };
+        deleteLink.innerHTML = deleteIconContent;
+        deleteLink.title = translate('delete_folder');
+
+        row.appendChild(dragIcon);
+        row.appendChild(colorInput);
+        row.appendChild(input);
+        row.appendChild(editLink);
+        row.appendChild(deleteLink);
+        container.appendChild(row);
+      } else {
+        showErrorMessage(responseData.message);
+      }
+    })
+    .catch(error => {
+      console.error(error);
+      showErrorMessage(translate('failed_add_folder'));
+    })
+    .finally(() => {
+      addButton.disabled = false;
+    });
+}
+
+
+function removeFolder(folderId) {
+  fetch('endpoints/folders/folder.php', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'X-CSRF-Token': window.csrfToken,
+    },
+    body: new URLSearchParams({
+      action: 'delete',
+      folderId: folderId,
+    }),
+  })
+    .then(response => {
+      if (!response.ok) {
+        throw new Error(translate('network_response_error'));
+      }
+      return response.json();
+    })
+    .then(responseData => {
+      if (responseData.success) {
+        const divToRemove = document.querySelector(`[data-folderid="${folderId}"]`);
+        if (divToRemove) divToRemove.remove();
+        showSuccessMessage(responseData.message);
+      } else {
+        showErrorMessage(responseData.message || translate('failed_remove_folder'));
+      }
+    })
+    .catch(error => {
+      console.error(error);
+      showErrorMessage(translate('failed_remove_folder'));
+    });
+}
+
+
+function editFolder(folderId) {
+  const saveButton = document.querySelector(`div[data-folderid="${folderId}"] button[name="save"]`);
+  const inputElement = document.querySelector(`div[data-folderid="${folderId}"] input[name="folder"]`);
+  const colorElement = document.querySelector(`div[data-folderid="${folderId}"] input[name="folder-color"]`);
+
+  if (!inputElement) return;
+
+  saveButton.classList.add("disabled");
+  saveButton.disabled = true;
+
+  const folderName = inputElement.value;
+  const folderColor = colorElement ? colorElement.value : "";
+
+  fetch('endpoints/folders/folder.php', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'X-CSRF-Token': window.csrfToken,
+    },
+    body: new URLSearchParams({
+      action: 'edit',
+      folderId: folderId,
+      name: folderName,
+      color: folderColor,
+    }),
+  })
+    .then(response => {
+      saveButton.classList.remove("disabled");
+      saveButton.disabled = false;
+
+      if (!response.ok) {
+        showErrorMessage(translate('failed_save_folder'));
+        throw new Error(translate('network_response_error'));
+      }
+      return response.json();
+    })
+    .then(responseData => {
+      if (responseData.success) {
+        showSuccessMessage(responseData.message);
+      } else {
+        showErrorMessage(responseData.message || translate('failed_save_folder'));
+      }
+    })
+    .catch(error => {
+      console.error(error);
+      showErrorMessage(translate('failed_save_folder'));
+      saveButton.classList.remove("disabled");
+      saveButton.disabled = false;
+    });
+}
+
+
 function addCurrencyButton(currencyId) {
   const addButton = document.getElementById("addCurrency");
   addButton.disabled = true;
@@ -1209,6 +1378,47 @@ var sortable = Sortable.create(el, {
     saveCategorySorting();
   },
 });
+
+function saveFolderSorting() {
+  const folders = document.getElementById("folders");
+  const folderIds = Array.from(folders.children).map(f => f.dataset.folderid);
+
+  const formData = new FormData();
+  folderIds.forEach(folderId => formData.append("folderIds[]", folderId));
+  formData.append("action", "sort");
+
+  fetch("endpoints/folders/folder.php", {
+    method: "POST",
+    headers: {"X-CSRF-Token": window.csrfToken},
+    body: formData,
+  })
+    .then(response => response.json())
+    .then(data => {
+      if (data.success) {
+        showSuccessMessage(data.message);
+      } else {
+        showErrorMessage(data.message);
+      }
+    })
+    .catch(error => {
+      console.error(error);
+      showErrorMessage(translate("unknown_error"));
+    });
+}
+
+var foldersEl = document.getElementById('folders');
+if (foldersEl) {
+  Sortable.create(foldersEl, {
+    handle: '.drag-icon',
+    ghostClass: 'sortable-ghost',
+    delay: 500,
+    delayOnTouchOnly: true,
+    touchStartThreshold: 5,
+    onEnd: function (evt) {
+      saveFolderSorting();
+    },
+  });
+}
 
 function fetch_ai_models() {
   const endpoint = 'endpoints/ai/fetch_models.php';

--- a/scripts/subscription-details.js
+++ b/scripts/subscription-details.js
@@ -157,6 +157,21 @@ function renderSubscriptionDetails(subscription) {
   document.querySelector('#details-next-payment').textContent = detailsFormatDate(subscription.next_payment);
   document.querySelector('#details-start-date').textContent = detailsFormatDate(subscription.start_date) || strings.none;
   document.querySelector('#details-category').textContent = lookups.categories[subscription.category_id] || strings.none;
+
+  const folder = lookups.folders ? lookups.folders[subscription.folder_id] : null;
+  const folderItem = document.querySelector('#details-folder-item');
+  if (folder) {
+    folderItem.classList.remove('hide');
+    const folderValue = document.querySelector('#details-folder');
+    folderValue.innerHTML = "";
+    const folderDot = document.createElement('span');
+    folderDot.className = 'folder-filter-dot';
+    folderDot.style.backgroundColor = folder.color;
+    folderValue.appendChild(folderDot);
+    folderValue.appendChild(document.createTextNode(folder.name));
+  } else {
+    folderItem.classList.add('hide');
+  }
   document.querySelector('#details-payer').textContent = lookups.members[subscription.payer_user_id] || strings.none;
 
   const paymentMethod = lookups.paymentMethods[subscription.payment_method_id];

--- a/scripts/subscriptions.js
+++ b/scripts/subscriptions.js
@@ -86,6 +86,10 @@ function fillEditFormFields(subscription) {
   paymentSelect.value = subscription.payment_method_id;
   const categorySelect = document.querySelector("#category");
   categorySelect.value = subscription.category_id;
+  const folderSelect = document.querySelector("#folder");
+  if (folderSelect) {
+    folderSelect.value = subscription.folder_id ?? 0;
+  }
   const payerSelect = document.querySelector("#payer_user");
   payerSelect.value = subscription.payer_user_id;
 
@@ -543,6 +547,9 @@ function fetchSubscriptions(id, event, initiator) {
   if (activeFilters['categories'].length > 0) {
     getSubscriptions += `?categories=${activeFilters['categories']}`;
   }
+  if (activeFilters['folders'].length > 0) {
+    getSubscriptions += getSubscriptions.includes("?") ? `&folders=${activeFilters['folders']}` : `?folders=${activeFilters['folders']}`;
+  }
   if (activeFilters['members'].length > 0) {
     getSubscriptions += getSubscriptions.includes("?") ? `&members=${activeFilters['members']}` : `?members=${activeFilters['members']}`;
   }
@@ -853,6 +860,7 @@ function setSwipeElements() {
 
 const activeFilters = [];
 activeFilters['categories'] = [];
+activeFilters['folders'] = [];
 activeFilters['members'] = [];
 activeFilters['payments'] = [];
 activeFilters['state'] = "";
@@ -919,6 +927,20 @@ document.querySelectorAll('.filter-item').forEach(function (item) {
         activeFilters['categories'].push(categoryId);
         this.classList.add('selected');
       }
+    } else if (this.hasAttribute('data-folderid')) {
+      const folderId = this.getAttribute('data-folderid');
+      if (activeFilters['folders'].includes(folderId)) {
+        const folderIndex = activeFilters['folders'].indexOf(folderId);
+        activeFilters['folders'].splice(folderIndex, 1);
+        this.classList.remove('selected');
+      } else {
+        activeFilters['folders'].push(folderId);
+        this.classList.add('selected');
+      }
+      const folderChip = document.querySelector(`.folder-chip[data-folderid="${folderId}"]`);
+      if (folderChip) {
+        folderChip.classList.toggle('selected', this.classList.contains('selected'));
+      }
     } else if (this.hasAttribute('data-memberid')) {
       const memberId = this.getAttribute('data-memberid');
       if (activeFilters['members'].includes(memberId)) {
@@ -975,7 +997,8 @@ document.querySelectorAll('.filter-item').forEach(function (item) {
       }
     }
 
-    if (activeFilters['categories'].length > 0 || activeFilters['members'].length > 0 ||
+    if (activeFilters['categories'].length > 0 || activeFilters['folders'].length > 0 ||
+       activeFilters['members'].length > 0 ||
        activeFilters['payments'].length > 0 || activeFilters['state'] !== "" ||
        activeFilters['renewalType'] !== "" || activeFilters['notifications'].length > 0) {
       document.querySelector('#clear-filters').classList.remove('hide');
@@ -987,10 +1010,24 @@ document.querySelectorAll('.filter-item').forEach(function (item) {
   });
 });
 
+// The folder chips above the list mirror the folder entries of the filter
+// menu: clicking a chip just clicks its menu counterpart so all the filter
+// bookkeeping lives in one place.
+document.querySelectorAll('.folder-chip').forEach(function (chip) {
+  chip.addEventListener('click', function () {
+    const folderId = this.getAttribute('data-folderid');
+    const menuItem = document.querySelector(`.filter-item[data-folderid="${folderId}"]`);
+    if (menuItem) {
+      menuItem.click();
+    }
+  });
+});
+
 function clearFilters() {
   const searchInput = document.querySelector("#search");
   searchInput.value = "";
   activeFilters['categories'] = [];
+  activeFilters['folders'] = [];
   activeFilters['members'] = [];
   activeFilters['payments'] = [];
   activeFilters['state'] = "";
@@ -999,6 +1036,9 @@ function clearFilters() {
 
   document.querySelectorAll('.filter-item').forEach(function (item) {
     item.classList.remove('selected');
+  });
+  document.querySelectorAll('.folder-chip').forEach(function (chip) {
+    chip.classList.remove('selected');
   });
   document.querySelector('#clear-filters').classList.add('hide');
   fetchSubscriptions(null, null, "clearfilters");

--- a/scripts/subscriptions.js
+++ b/scripts/subscriptions.js
@@ -937,9 +937,9 @@ document.querySelectorAll('.filter-item').forEach(function (item) {
         activeFilters['folders'].push(folderId);
         this.classList.add('selected');
       }
-      const folderChip = document.querySelector(`.folder-chip[data-folderid="${folderId}"]`);
-      if (folderChip) {
-        folderChip.classList.toggle('selected', this.classList.contains('selected'));
+      const folderCard = document.querySelector(`.folder-card[data-folderid="${folderId}"]`);
+      if (folderCard) {
+        folderCard.classList.toggle('selected', this.classList.contains('selected'));
       }
     } else if (this.hasAttribute('data-memberid')) {
       const memberId = this.getAttribute('data-memberid');
@@ -1013,7 +1013,7 @@ document.querySelectorAll('.filter-item').forEach(function (item) {
 // The folder chips above the list mirror the folder entries of the filter
 // menu: clicking a chip just clicks its menu counterpart so all the filter
 // bookkeeping lives in one place.
-document.querySelectorAll('.folder-chip').forEach(function (chip) {
+document.querySelectorAll('.folder-card').forEach(function (chip) {
   chip.addEventListener('click', function () {
     const folderId = this.getAttribute('data-folderid');
     const menuItem = document.querySelector(`.filter-item[data-folderid="${folderId}"]`);
@@ -1037,7 +1037,7 @@ function clearFilters() {
   document.querySelectorAll('.filter-item').forEach(function (item) {
     item.classList.remove('selected');
   });
-  document.querySelectorAll('.folder-chip').forEach(function (chip) {
+  document.querySelectorAll('.folder-card').forEach(function (chip) {
     chip.classList.remove('selected');
   });
   document.querySelector('#clear-filters').classList.add('hide');

--- a/settings.php
+++ b/settings.php
@@ -1010,6 +1010,61 @@ if ($budgetPeriodAnchorDate === '1970-01-01' || !preg_match('/^\d{4}-\d{2}-\d{2}
     </section>
 
     <?php
+    $sql = "SELECT * FROM folders WHERE user_id = :userId ORDER BY `order` ASC";
+    $stmt = $db->prepare($sql);
+    $stmt->bindValue(':userId', $userId, SQLITE3_INTEGER);
+    $result = $stmt->execute();
+
+    if ($result) {
+        $folders = array();
+        while ($row = $result->fetchArray(SQLITE3_ASSOC)) {
+            $folders[] = $row;
+        }
+    }
+    ?>
+
+    <section class="account-section">
+        <header>
+            <h2><?= translate('folders', $i18n) ?></h2>
+        </header>
+        <div class="account-categories">
+            <div class="settings-notes">
+                <p>
+                    <i class="fa-solid fa-circle-info"></i> <?= translate('folders_explanation', $i18n) ?>
+                </p>
+            </div>
+            <div id="folders" class="sortable-list">
+                <?php
+                foreach ($folders as $folder) {
+                    ?>
+                    <div class="form-group-inline" data-folderid="<?= $folder['id'] ?>">
+                        <div class=" drag-icon"><i class="fa-solid fa-grip-vertical"></i></div>
+                        <input type="color" name="folder-color" class="folder-color-picker"
+                            value="<?= htmlspecialchars($folder['color']) ?>"
+                            title="<?= translate('folder_color', $i18n) ?>">
+                        <input type="text" name="folder" autocomplete="off" value="<?= htmlspecialchars($folder['name']) ?>"
+                            placeholder="<?= translate('folder', $i18n) ?>">
+                        <button class="image-button medium" onClick="editFolder(<?= $folder['id'] ?>)" name="save"
+                            title="<?= translate('save_folder', $i18n) ?>">
+                            <i class="fa-solid fa-check"></i>
+                        </button>
+                        <button class="image-button medium" onClick="removeFolder(<?= $folder['id'] ?>)"
+                            title="<?= translate('delete_folder', $i18n) ?>">
+                            <i class="fa-solid fa-trash-can"></i>
+                        </button>
+                    </div>
+                    <?php
+                }
+                ?>
+            </div>
+            <div class="buttons">
+                <input type="submit" value="<?= translate('add', $i18n) ?>" id="addFolder"
+                    onClick="addFolderButton()" class="thin mobile-grow" />
+            </div>
+        </div>
+    </section>
+
+    <?php
     $sql = "SELECT * FROM currencies WHERE user_id = :userId";
     $stmt = $db->prepare($sql);
     $stmt->bindValue(':userId', $userId, SQLITE3_INTEGER);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -4318,49 +4318,118 @@ body.details-open {
 }
 
 /* Folders ("pockets") */
-.folder-chips {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-bottom: 16px;
+.folder-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 14px;
+  margin-bottom: 24px;
 }
 
-.folder-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 7px 14px;
-  border-radius: 999px;
-  border: 1px solid var(--box-border-color);
-  background-color: var(--box-background-color);
-  box-shadow: var(--box-shadow);
+.folder-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 3px;
+  margin-top: 12px;
+  padding: 16px 16px 14px;
+  border-radius: 4px 14px 14px 14px;
+  border: 1px solid color-mix(in srgb, var(--folder-color) 35%, var(--box-border-color));
+  background: linear-gradient(
+    color-mix(in srgb, var(--folder-color) 16%, var(--box-background-color)),
+    color-mix(in srgb, var(--folder-color) 8%, var(--box-background-color))
+  );
   color: var(--text-color);
   font-family: inherit;
-  font-size: 14px;
+  text-align: left;
   cursor: pointer;
-  transition: border-color 0.2s, background-color 0.2s, box-shadow 0.2s;
+  transition: border-color 0.2s, box-shadow 0.2s, transform 0.2s;
 }
 
-.folder-chip i {
+/* The folder tab */
+.folder-card::before {
+  content: "";
+  position: absolute;
+  top: -12px;
+  left: -1px;
+  width: 45%;
+  min-width: 60px;
+  height: 12px;
+  border-radius: 8px 12px 0 0;
+  border: 1px solid color-mix(in srgb, var(--folder-color) 35%, var(--box-border-color));
+  border-bottom: none;
+  background: color-mix(in srgb, var(--folder-color) 45%, var(--box-background-color));
+}
+
+.folder-card:hover {
+  border-color: var(--folder-color);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 14px -6px color-mix(in srgb, var(--folder-color) 60%, transparent);
+}
+
+.folder-card.selected {
+  border-color: var(--folder-color);
+  background: linear-gradient(
+    color-mix(in srgb, var(--folder-color) 32%, var(--box-background-color)),
+    color-mix(in srgb, var(--folder-color) 18%, var(--box-background-color))
+  );
+  box-shadow: 0 6px 14px -6px color-mix(in srgb, var(--folder-color) 60%, transparent);
+}
+
+.folder-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+}
+
+.folder-card-name {
+  font-weight: 600;
+  font-size: 16px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.folder-card-check {
   color: var(--folder-color);
+  opacity: 0;
+  transition: opacity 0.2s;
 }
 
-.folder-chip:hover {
-  border-color: var(--folder-color);
+.folder-card.selected .folder-card-check {
+  opacity: 1;
 }
 
-.folder-chip.selected {
-  border-color: var(--folder-color);
-  background-color: color-mix(in srgb, var(--folder-color) 14%, var(--box-background-color));
-}
-
-.folder-chip-name {
-  font-weight: 500;
-}
-
-.folder-chip-count {
-  font-size: 12px;
+.folder-card-meta {
+  font-size: 13px;
   opacity: 0.7;
+  text-transform: lowercase;
+}
+
+.folder-card-total {
+  margin-top: 6px;
+  font-size: 15px;
+  font-weight: 600;
+  color: color-mix(in srgb, var(--folder-color) 65%, var(--text-color));
+}
+
+.folder-card-total-period {
+  font-size: 12px;
+  font-weight: 400;
+  opacity: 0.75;
+}
+
+@media (max-width: 768px) {
+  .folder-cards {
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    gap: 10px 12px;
+  }
+
+  .folder-card {
+    padding: 12px 12px 10px;
+  }
 }
 
 .subscription.in-folder {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -4316,3 +4316,74 @@ body.details-open {
 .api-usage-fill.danger {
   background-color: var(--error-color);
 }
+
+/* Folders ("pockets") */
+.folder-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.folder-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 14px;
+  border-radius: 999px;
+  border: 1px solid var(--box-border-color);
+  background-color: var(--box-background-color);
+  box-shadow: var(--box-shadow);
+  color: var(--text-color);
+  font-family: inherit;
+  font-size: 14px;
+  cursor: pointer;
+  transition: border-color 0.2s, background-color 0.2s, box-shadow 0.2s;
+}
+
+.folder-chip i {
+  color: var(--folder-color);
+}
+
+.folder-chip:hover {
+  border-color: var(--folder-color);
+}
+
+.folder-chip.selected {
+  border-color: var(--folder-color);
+  background-color: color-mix(in srgb, var(--folder-color) 14%, var(--box-background-color));
+}
+
+.folder-chip-name {
+  font-weight: 500;
+}
+
+.folder-chip-count {
+  font-size: 12px;
+  opacity: 0.7;
+}
+
+.subscription.in-folder {
+  border-left: 4px solid var(--folder-color);
+}
+
+.folder-filter-dot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  margin-right: 6px;
+  flex-shrink: 0;
+  vertical-align: middle;
+}
+
+.folder-color-picker {
+  flex-shrink: 0;
+  width: 44px;
+  height: 44px;
+  padding: 2px;
+  border: 1px solid var(--box-border-color);
+  border-radius: 10px;
+  background-color: var(--box-background-color);
+  cursor: pointer;
+}

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -4432,10 +4432,6 @@ body.details-open {
   }
 }
 
-.subscription.in-folder {
-  border-left: 4px solid var(--folder-color);
-}
-
 .folder-filter-dot {
   display: inline-block;
   width: 10px;

--- a/subscriptions.php
+++ b/subscriptions.php
@@ -65,6 +65,19 @@ if (isset($_GET['category'])) {
   }
 }
 
+if (isset($_GET['folder'])) {
+  $folderIds = explode(',', $_GET['folder']);
+  $placeholders = array_map(function ($key) {
+    return ":folder{$key}";
+  }, array_keys($folderIds));
+
+  $sql .= " AND folder_id IN (" . implode(',', $placeholders) . ")";
+
+  foreach ($folderIds as $key => $folderId) {
+    $params[":folder{$key}"] = $folderId;
+  }
+}
+
 if (isset($_GET['payment'])) {
   $paymentIds = explode(',', $_GET['payment']);
   $placeholders = array_map(function ($key) {
@@ -132,6 +145,10 @@ foreach ($subscriptions as $subscription) {
   $categories[$categoryId]['count']++;
   $paymentMethodId = $subscription['payment_method_id'];
   $payment_methods[$paymentMethodId]['count']++;
+  $folderId = $subscription['folder_id'] ?? null;
+  if ($folderId !== null && isset($folders[$folderId])) {
+    $folders[$folderId]['count']++;
+  }
 }
 
 if ($sortOrder == "category_id") {
@@ -201,6 +218,33 @@ $subscriptionsView = (isset($_COOKIE['subscriptionsView']) && $_COOKIE['subscrip
       </div>
     </div>
   </header>
+  <?php
+  if (count($folders) > 0) {
+    ?>
+    <div class="folder-chips" id="folder-chips">
+      <?php
+      foreach ($folders as $folder) {
+        $selectedClass = '';
+        if (isset($_GET['folder'])) {
+          $selectedFolderIds = explode(',', $_GET['folder']);
+          if (in_array($folder['id'], $selectedFolderIds)) {
+            $selectedClass = ' selected';
+          }
+        }
+        ?>
+        <button type="button" class="folder-chip<?= $selectedClass ?>" data-folderid="<?= $folder['id'] ?>"
+          style="--folder-color: <?= htmlspecialchars($folder['color']) ?>">
+          <i class="fa-solid fa-folder"></i>
+          <span class="folder-chip-name"><?= $folder['name'] ?></span>
+          <span class="folder-chip-count"><?= $folder['count'] ?></span>
+        </button>
+        <?php
+      }
+      ?>
+    </div>
+    <?php
+  }
+  ?>
   <div class="subscriptions<?= $subscriptionsView === 'grid' ? ' grid-view' : '' ?>" id="subscriptions">
     <?php
     $formatter = new IntlDateFormatter(
@@ -239,6 +283,7 @@ $subscriptionsView = (isset($_COOKIE['subscriptionsView']) && $_COOKIE['subscrip
       $print[$id]['payment_method_name'] = $payment_methods[$paymentMethodId]['name'];
       $print[$id]['payment_method_id'] = $paymentMethodId;
       $print[$id]['category_id'] = $subscription['category_id'];
+      $print[$id]['folder_id'] = $subscription['folder_id'] ?? null;
       $print[$id]['payer_user_id'] = $subscription['payer_user_id'];
       $print[$id]['price'] = floatval($subscription['price']);
       $print[$id]['progress'] = getSubscriptionProgress($cycle, $frequency, $subscription['next_payment']);
@@ -272,7 +317,7 @@ $subscriptionsView = (isset($_COOKIE['subscriptionsView']) && $_COOKIE['subscrip
     }
 
     if (isset($print)) {
-      printSubscriptions($print, $sort, $categories, $members, $i18n, $colorTheme, "", $settings['disabledToBottom'], $settings['mobileNavigation'], $settings['showSubscriptionProgress'], $currencies, $lang);
+      printSubscriptions($print, $sort, $categories, $folders, $members, $i18n, $colorTheme, "", $settings['disabledToBottom'], $settings['mobileNavigation'], $settings['showSubscriptionProgress'], $currencies, $lang);
     }
 
     $googleSearchEnabled = false;
@@ -479,6 +524,28 @@ $subscriptionsView = (isset($_COOKIE['subscriptionsView']) && $_COOKIE['subscrip
         ?>
       </select>
     </div>
+
+    <?php
+    if (count($folders) > 0) {
+      ?>
+      <div class="form-group">
+        <label for="folder"><?= translate('folder', $i18n) ?></label>
+        <select id="folder" name="folder_id">
+          <option value="0"><?= translate('no_folder', $i18n) ?></option>
+          <?php
+          foreach ($folders as $folder) {
+            ?>
+            <option value="<?= $folder['id'] ?>">
+              <?= $folder['name'] ?>
+            </option>
+            <?php
+          }
+          ?>
+        </select>
+      </div>
+      <?php
+    }
+    ?>
 
     <div class="form-group-inline grow" id="notifications-group">
       <input type="checkbox" id="notifications" name="notifications" onchange="toggleNotificationDays()">

--- a/subscriptions.php
+++ b/subscriptions.php
@@ -148,6 +148,14 @@ foreach ($subscriptions as $subscription) {
   $folderId = $subscription['folder_id'] ?? null;
   if ($folderId !== null && isset($folders[$folderId])) {
     $folders[$folderId]['count']++;
+    if (!$subscription['inactive']) {
+      $folderPrice = floatval($subscription['price']);
+      if ($subscription['currency_id'] != $mainCurrencyId) {
+        $folderPrice = getPriceConverted($folderPrice, $subscription['currency_id'], $db);
+      }
+      $folders[$folderId]['monthly_total'] = ($folders[$folderId]['monthly_total'] ?? 0)
+        + getPricePerMonth($subscription['cycle'], $subscription['frequency'], $folderPrice);
+    }
   }
 }
 
@@ -221,7 +229,7 @@ $subscriptionsView = (isset($_COOKIE['subscriptionsView']) && $_COOKIE['subscrip
   <?php
   if (count($folders) > 0) {
     ?>
-    <div class="folder-chips" id="folder-chips">
+    <div class="folder-cards" id="folder-cards">
       <?php
       foreach ($folders as $folder) {
         $selectedClass = '';
@@ -231,12 +239,19 @@ $subscriptionsView = (isset($_COOKIE['subscriptionsView']) && $_COOKIE['subscrip
             $selectedClass = ' selected';
           }
         }
+        $folderMonthlyTotal = $folder['monthly_total'] ?? 0;
         ?>
-        <button type="button" class="folder-chip<?= $selectedClass ?>" data-folderid="<?= $folder['id'] ?>"
+        <button type="button" class="folder-card<?= $selectedClass ?>" data-folderid="<?= $folder['id'] ?>"
           style="--folder-color: <?= htmlspecialchars($folder['color']) ?>">
-          <i class="fa-solid fa-folder"></i>
-          <span class="folder-chip-name"><?= $folder['name'] ?></span>
-          <span class="folder-chip-count"><?= $folder['count'] ?></span>
+          <span class="folder-card-header">
+            <span class="folder-card-name"><?= $folder['name'] ?></span>
+            <span class="folder-card-check"><i class="fa-solid fa-circle-check"></i></span>
+          </span>
+          <span class="folder-card-meta"><?= $folder['count'] ?> <?= translate('subscriptions', $i18n) ?></span>
+          <span class="folder-card-total">
+            <?= formatPrice($folderMonthlyTotal, $currencies[$mainCurrencyId]['code'], $currencies) ?>
+            <span class="folder-card-total-period">/ <?= translate('per_month', $i18n) ?></span>
+          </span>
         </button>
         <?php
       }


### PR DESCRIPTION
## What this PR does

Adds **folders**: a lightweight, colored way to group subscriptions into "pockets" (e.g. Personal / Family / Work), independent from categories — a subscription keeps its category *and* can live in a folder.

### Features

- **Folders section in Settings**: create, rename, pick a color, drag-and-drop reorder, delete. Deleting a folder simply detaches its subscriptions (never deletes them).
- **Folder select in the subscription form** (only shown when at least one folder exists), persisted through add/edit/clone and the details endpoints.
- **Folder cards on the subscriptions page**: large folder-shaped cards (colored tab + tinted background) showing the subscription count and the monthly total converted to the main currency. Clicking a card filters the list.
- **Folder entry in the filters menu** (with color dot), combinable with the other filters, plus a folder row in the subscription details popup.
- New folders automatically get a distinct color from an 8-color palette, customizable afterwards.

### Technical notes

- Migration `000054`: new `folders` table + nullable `folder_id` column on `subscriptions`.
- New endpoint `endpoints/folders/folder.php` (add/edit/delete/sort), modeled after the categories endpoint (CSRF-protected, per-user scoping, hex color validation).
- i18n: keys added to `en` and `fr` for PHP (other languages fall back to English), and to **all** JS locale files (the JS `translate()` has no fallback).
- No behavior change for users without folders: the cards row, form field and filter entry only render when folders exist.

### Screenshots

<img width="2032" height="1162" alt="Capture d’écran 2026-08-12 à 10 45 03" src="https://github.com/user-attachments/assets/39972768-0c0c-47c1-9a79-3b3be7c0a48c" />
<img width="2032" height="1162" alt="Capture d’écran 2026-08-12 à 10 45 13" src="https://github.com/user-attachments/assets/b6fa431f-ad30-4636-8abf-c62a83c91122" />


### Testing

- Migration runs cleanly on an existing database and on a fresh install.
- CRUD, filtering (AJAX + URL param), monthly totals, currency conversion and FR/EN translations verified on a locally built Docker image.