### PR TITLE
fix: scope currency rate updates to the user being refreshed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,18 @@ We welcome contributions from the community and look forward to working with you
 
 4.  **Make your changes:** Implement your feature or bug fix.
 5.  **Test your changes:** Ensure that your changes work as expected.
+
+    Wallos has a small test suite in `tests/`. It needs no Composer or local PHP
+    installation — it runs in a throwaway container:
+
+    ```bash
+    dev/test.sh             # all cases
+    dev/test.sh currency    # only cases matching "currency"
+    ```
+
+    Use `CONTAINER_ENGINE=docker dev/test.sh` if you prefer Docker over Podman.
+    Tests build the real schema by running `createdatabase.php` and the
+    migration chain, so they exercise the schema the application produces.
 6.  **Commit your changes:** Commit your changes with a clear and concise message:
 
     ```bash

--- a/dev/test.sh
+++ b/dev/test.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Runs the test suite in a throwaway PHP container, so no local PHP is needed.
+#
+#   dev/test.sh              every case
+#   dev/test.sh currency     cases matching "currency"
+
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+ENGINE=${CONTAINER_ENGINE:-podman}
+
+exec "$ENGINE" run --rm \
+    -v "$ROOT":/var/www/html:Z \
+    -w /var/www/html \
+    docker.io/library/php:8.3-cli \
+    php tests/run.php "$@"

--- a/endpoints/cronjobs/updateexchange.php
+++ b/endpoints/cronjobs/updateexchange.php
@@ -73,10 +73,13 @@ while ($userToUpdateExchange = $usersToUpdateExchange->fetchArray(SQLITE3_ASSOC)
                     } else {
                         $exchangeRate = $rate / $mainCurrencyToEUR;
                     }
-                    $updateQuery = "UPDATE currencies SET rate = :rate WHERE code = :code";
+                    // Every user has their own currency rows, converted against their own
+                    // main currency, so the write must be scoped to the user being refreshed.
+                    $updateQuery = "UPDATE currencies SET rate = :rate WHERE code = :code AND user_id = :userId";
                     $updateStmt = $db->prepare($updateQuery);
                     $updateStmt->bindParam(':rate', $exchangeRate, SQLITE3_TEXT);
                     $updateStmt->bindParam(':code', $currencyCode, SQLITE3_TEXT);
+                    $updateStmt->bindParam(':userId', $userId, SQLITE3_INTEGER);
                     $updateResult = $updateStmt->execute();
 
                     if (!$updateResult) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,256 @@
+<?php
+/*
+  Minimal test harness for Wallos.
+
+  Wallos vendors its libraries instead of using Composer, so the tests follow
+  the same principle: no external dependency, just PHP and the SQLite
+  extension the application already requires.
+
+  A test file registers cases with wallos_test() and asserts with the assert_*
+  helpers. tests/run.php discovers and runs them.
+*/
+
+define('WALLOS_ROOT', dirname(__DIR__));
+define('WALLOS_TEST_TMP', sys_get_temp_dir() . '/wallos-tests');
+
+$GLOBALS['wallos_tests'] = [];
+$GLOBALS['wallos_test_failures'] = [];
+$GLOBALS['wallos_test_assertions'] = 0;
+$GLOBALS['wallos_test_current'] = null;
+
+/**
+ * Registers one test case.
+ *
+ * @param string   $name
+ * @param callable $body
+ */
+function wallos_test($name, callable $body)
+{
+    $GLOBALS['wallos_tests'][] = ['name' => $name, 'body' => $body];
+}
+
+function wallos_test_fail($message)
+{
+    $GLOBALS['wallos_test_failures'][] = [
+        'test' => $GLOBALS['wallos_test_current'],
+        'message' => $message,
+    ];
+}
+
+function assert_true($condition, $message)
+{
+    $GLOBALS['wallos_test_assertions']++;
+
+    if (!$condition) {
+        wallos_test_fail($message);
+    }
+}
+
+function assert_same($expected, $actual, $message)
+{
+    $GLOBALS['wallos_test_assertions']++;
+
+    if ($expected !== $actual) {
+        wallos_test_fail(sprintf(
+            '%s (expected %s, got %s)',
+            $message,
+            var_export($expected, true),
+            var_export($actual, true)
+        ));
+    }
+}
+
+function assert_equals($expected, $actual, $message)
+{
+    $GLOBALS['wallos_test_assertions']++;
+
+    if ($expected != $actual) {
+        wallos_test_fail(sprintf(
+            '%s (expected %s, got %s)',
+            $message,
+            var_export($expected, true),
+            var_export($actual, true)
+        ));
+    }
+}
+
+function assert_contains($needle, $haystack, $message)
+{
+    $GLOBALS['wallos_test_assertions']++;
+
+    if (strpos((string) $haystack, (string) $needle) === false) {
+        wallos_test_fail($message . ' (missing: ' . $needle . ')');
+    }
+}
+
+function assert_not_contains($needle, $haystack, $message)
+{
+    $GLOBALS['wallos_test_assertions']++;
+
+    if (strpos((string) $haystack, (string) $needle) !== false) {
+        wallos_test_fail($message . ' (unexpectedly present: ' . $needle . ')');
+    }
+}
+
+/**
+ * Builds the real application schema once per run by running the same
+ * createdatabase.php and migration chain the container startup uses, then
+ * hands out a fresh copy of it per test.
+ *
+ * The application resolves its database path relative to its own directory, so
+ * the schema is built inside a throwaway copy of the source tree rather than in
+ * the working copy.
+ *
+ * @return string Path to the freshly copied database.
+ */
+function wallos_test_database()
+{
+    static $template = null;
+
+    if ($template === null) {
+        $sandbox = WALLOS_TEST_TMP . '/sandbox';
+
+        if (!is_dir($sandbox)) {
+            mkdir($sandbox, 0700, true);
+            foreach (['endpoints/cronjobs', 'includes', 'migrations', 'db'] as $directory) {
+                mkdir($sandbox . '/' . $directory, 0700, true);
+            }
+
+            foreach (glob(WALLOS_ROOT . '/migrations/*.php') as $migration) {
+                copy($migration, $sandbox . '/migrations/' . basename($migration));
+            }
+            copy(WALLOS_ROOT . '/endpoints/cronjobs/createdatabase.php', $sandbox . '/endpoints/cronjobs/createdatabase.php');
+            copy(WALLOS_ROOT . '/includes/run_migrations.php', $sandbox . '/includes/run_migrations.php');
+        }
+
+        $databaseFile = $sandbox . '/db/wallos.db';
+
+        if (!file_exists($databaseFile)) {
+            // Both scripts print progress and resolve their paths from __DIR__,
+            // which is why they run inside the sandbox copy.
+            ob_start();
+            require $sandbox . '/endpoints/cronjobs/createdatabase.php';
+            $db = new SQLite3($databaseFile);
+            $db->busyTimeout(5000);
+            require $sandbox . '/includes/run_migrations.php';
+            $db->close();
+            ob_end_clean();
+        }
+
+        $template = $databaseFile;
+    }
+
+    $copy = WALLOS_TEST_TMP . '/case-' . uniqid('', true) . '.db';
+    copy($template, $copy);
+
+    return $copy;
+}
+
+/**
+ * Opens a fresh database with the full application schema.
+ *
+ * @return SQLite3
+ */
+function wallos_test_open_database()
+{
+    $db = new SQLite3(wallos_test_database());
+    $db->busyTimeout(5000);
+
+    return $db;
+}
+
+/**
+ * SQLite3 wrapper that counts statements, so tests can assert that a code path
+ * does not issue one query per row.
+ */
+class WallosCountingDatabase extends SQLite3
+{
+    public $queryCount = 0;
+
+    public function prepare($query): SQLite3Stmt|false
+    {
+        $this->queryCount++;
+
+        return parent::prepare($query);
+    }
+
+    public function query($query): SQLite3Result|false
+    {
+        $this->queryCount++;
+
+        return parent::query($query);
+    }
+
+    public function querySingle($query, $entireRow = false): mixed
+    {
+        $this->queryCount++;
+
+        return parent::querySingle($query, $entireRow);
+    }
+
+    public function resetQueryCount()
+    {
+        $this->queryCount = 0;
+    }
+}
+
+/**
+ * @return WallosCountingDatabase
+ */
+function wallos_test_open_counting_database()
+{
+    $db = new WallosCountingDatabase(wallos_test_database());
+    $db->busyTimeout(5000);
+
+    return $db;
+}
+
+/**
+ * Inserts a user together with the currency rows Wallos creates alongside it.
+ *
+ * @param SQLite3 $db
+ * @param int     $id
+ * @param string  $username
+ */
+function wallos_test_create_user($db, $id, $username)
+{
+    $stmt = $db->prepare("INSERT INTO user (id, username, email, password, main_currency) VALUES (:id, :username, :email, 'x', 1)");
+    $stmt->bindValue(':id', $id, SQLITE3_INTEGER);
+    $stmt->bindValue(':username', $username, SQLITE3_TEXT);
+    $stmt->bindValue(':email', $username . '@example.com', SQLITE3_TEXT);
+    $stmt->execute();
+
+    // createdatabase.php seeds a default currency list; the fixture replaces it
+    // so a test can reason about exactly two rows per user.
+    $stmt = $db->prepare('DELETE FROM currencies WHERE user_id = :userId');
+    $stmt->bindValue(':userId', $id, SQLITE3_INTEGER);
+    $stmt->execute();
+
+    foreach ([['EUR', 'Euro', 1.0], ['USD', 'US Dollar', 1.1]] as $index => $currency) {
+        $stmt = $db->prepare('INSERT INTO currencies (id, name, symbol, code, rate, user_id) VALUES (:id, :name, :symbol, :code, :rate, :userId)');
+        $stmt->bindValue(':id', wallos_test_currency_id($id, $index), SQLITE3_INTEGER);
+        $stmt->bindValue(':name', $currency[1], SQLITE3_TEXT);
+        $stmt->bindValue(':symbol', $currency[0] === 'EUR' ? "\u{20AC}" : '$', SQLITE3_TEXT);
+        $stmt->bindValue(':code', $currency[0], SQLITE3_TEXT);
+        $stmt->bindValue(':rate', $currency[2], SQLITE3_FLOAT);
+        $stmt->bindValue(':userId', $id, SQLITE3_INTEGER);
+        $stmt->execute();
+    }
+
+    $stmt = $db->prepare('UPDATE user SET main_currency = :currencyId WHERE id = :id');
+    $stmt->bindValue(':currencyId', wallos_test_currency_id($id, 0), SQLITE3_INTEGER);
+    $stmt->bindValue(':id', $id, SQLITE3_INTEGER);
+    $stmt->execute();
+}
+
+/**
+ * Fixture currency ids live above the seeded default list so they never clash.
+ *
+ * @param int $userId
+ * @param int $index   0 = EUR (main currency), 1 = USD
+ * @return int
+ */
+function wallos_test_currency_id($userId, $index)
+{
+    return 9000 + ($userId * 10) + $index;
+}

--- a/tests/cases/currency_scope_test.php
+++ b/tests/cases/currency_scope_test.php
@@ -1,0 +1,97 @@
+<?php
+/*
+  Refreshing one user's exchange rates must never touch another user's rows.
+
+  Wallos stores one currency row per user, and each user's rate is derived from
+  their own main currency. A rate update that matches on the currency code alone
+  therefore overwrites other users' rates with a conversion base that is not
+  theirs.
+*/
+
+/**
+ * Seeds two users whose currencies overlap but whose main currency differs.
+ *
+ * @param SQLite3 $db
+ */
+function currency_scope_fixture($db)
+{
+    wallos_test_create_user($db, 1, 'alice');
+    wallos_test_create_user($db, 2, 'bob');
+
+    // Bob's rates are deliberately distinct so any cross-user write is visible.
+    $stmt = $db->prepare('UPDATE currencies SET rate = 2.5 WHERE user_id = 2');
+    $stmt->execute();
+}
+
+/**
+ * @param SQLite3 $db
+ * @param int     $userId
+ * @param string  $code
+ * @return float
+ */
+function currency_scope_rate($db, $userId, $code)
+{
+    $stmt = $db->prepare('SELECT rate FROM currencies WHERE user_id = :userId AND code = :code');
+    $stmt->bindValue(':userId', $userId, SQLITE3_INTEGER);
+    $stmt->bindValue(':code', $code, SQLITE3_TEXT);
+    $result = $stmt->execute();
+    $row = $result ? $result->fetchArray(SQLITE3_ASSOC) : false;
+
+    return $row ? (float) $row['rate'] : 0.0;
+}
+
+wallos_test('rate updates are scoped to one user', function () {
+    $db = wallos_test_open_database();
+    currency_scope_fixture($db);
+
+    $before = currency_scope_rate($db, 2, 'USD');
+
+    // The update statement used by the refresh path.
+    $stmt = $db->prepare('UPDATE currencies SET rate = :rate WHERE code = :code AND user_id = :userId');
+    $stmt->bindValue(':rate', 9.99, SQLITE3_FLOAT);
+    $stmt->bindValue(':code', 'USD', SQLITE3_TEXT);
+    $stmt->bindValue(':userId', 1, SQLITE3_INTEGER);
+    $stmt->execute();
+
+    assert_same(9.99, currency_scope_rate($db, 1, 'USD'), "alice's rate is updated");
+    assert_same($before, currency_scope_rate($db, 2, 'USD'), "bob's rate is untouched");
+
+    $db->close();
+});
+
+wallos_test('an unscoped rate update would corrupt other users', function () {
+    // Guards the regression itself: if this ever stops being true, the scoped
+    // statement above has lost its purpose.
+    $db = wallos_test_open_database();
+    currency_scope_fixture($db);
+
+    $stmt = $db->prepare('UPDATE currencies SET rate = :rate WHERE code = :code');
+    $stmt->bindValue(':rate', 9.99, SQLITE3_FLOAT);
+    $stmt->bindValue(':code', 'USD', SQLITE3_TEXT);
+    $stmt->execute();
+
+    assert_same(9.99, currency_scope_rate($db, 2, 'USD'), 'unscoped update reaches every user');
+
+    $db->close();
+});
+
+wallos_test('every currency rate update in the code base is user scoped', function () {
+    // The regression guard: any future rate write that forgets the user filter
+    // fails here rather than silently corrupting other accounts in production.
+    $paths = [
+        'endpoints/cronjobs/updateexchange.php',
+        'endpoints/currency/update_exchange.php',
+    ];
+
+    foreach ($paths as $path) {
+        $source = file_get_contents(WALLOS_ROOT . '/' . $path);
+
+        preg_match_all('/UPDATE\s+currencies\s+SET\s+rate[^"\']*/i', $source, $matches);
+        assert_true($matches[0] !== [], $path . ' still contains a rate update');
+
+        foreach ($matches[0] as $statement) {
+            assert_contains('user_id', $statement,
+                $path . ' updates rates without scoping them to a user: ' . trim($statement));
+        }
+    }
+});

--- a/tests/run.php
+++ b/tests/run.php
@@ -1,0 +1,88 @@
+<?php
+/*
+  Test runner.
+
+      php tests/run.php              run every case
+      php tests/run.php currency     run cases whose file or name matches "currency"
+
+  Exits non-zero when a case fails, so it can be used in CI.
+*/
+
+require_once __DIR__ . '/bootstrap.php';
+
+$filter = $argv[1] ?? null;
+
+if (is_dir(WALLOS_TEST_TMP)) {
+    foreach (glob(WALLOS_TEST_TMP . '/case-*.db') as $leftover) {
+        @unlink($leftover);
+    }
+} else {
+    mkdir(WALLOS_TEST_TMP, 0700, true);
+}
+
+$files = glob(__DIR__ . '/cases/*_test.php');
+sort($files);
+
+foreach ($files as $file) {
+    if ($filter !== null && stripos(basename($file), $filter) === false) {
+        // Keep the file when one of its case names matches instead.
+        $contents = file_get_contents($file);
+        if (stripos($contents, $filter) === false) {
+            continue;
+        }
+    }
+
+    require_once $file;
+}
+
+$started = microtime(true);
+$passed = 0;
+$failedTests = [];
+
+foreach ($GLOBALS['wallos_tests'] as $test) {
+    if ($filter !== null
+        && stripos($test['name'], $filter) === false
+        && stripos(basename((new ReflectionFunction($test['body']))->getFileName()), $filter) === false) {
+        continue;
+    }
+
+    $GLOBALS['wallos_test_current'] = $test['name'];
+    $before = count($GLOBALS['wallos_test_failures']);
+
+    try {
+        $test['body']();
+    } catch (Throwable $error) {
+        wallos_test_fail('threw ' . get_class($error) . ': ' . $error->getMessage()
+            . ' @ ' . basename($error->getFile()) . ':' . $error->getLine());
+    }
+
+    $newFailures = array_slice($GLOBALS['wallos_test_failures'], $before);
+
+    if ($newFailures === []) {
+        $passed++;
+        echo "\033[32m  ok\033[0m  " . $test['name'] . "\n";
+
+        continue;
+    }
+
+    $failedTests[] = $test['name'];
+    echo "\033[31mFAIL\033[0m  " . $test['name'] . "\n";
+    foreach ($newFailures as $failure) {
+        echo "        " . $failure['message'] . "\n";
+    }
+}
+
+foreach (glob(WALLOS_TEST_TMP . '/case-*.db') as $leftover) {
+    @unlink($leftover);
+}
+
+$duration = round((microtime(true) - $started) * 1000);
+$failures = count($GLOBALS['wallos_test_failures']);
+
+echo "\n";
+echo $failures === 0
+    ? sprintf("\033[32m%d tests passed\033[0m (%d assertions, %dms)\n", $passed, $GLOBALS['wallos_test_assertions'], $duration)
+    : sprintf("\033[31m%d failing assertion(s)\033[0m in %d test(s), %d passed (%dms)\n",
+        $failures, count($failedTests), $passed, $duration);
+
+exit($failures === 0 ? 0 : 1);


### PR DESCRIPTION
## The problem

`endpoints/cronjobs/updateexchange.php` updates currency rows by code alone:

```php
$updateQuery = "UPDATE currencies SET rate = :rate WHERE code = :code";
```

Every user has their own rows in `currencies`, and the rate stored there is already converted against **that user's** main currency:

```php
$exchangeRate = $rate / $mainCurrencyToEUR;   // $mainCurrencyToEUR is this user's base
```

So on each scheduled run, the last user processed overwrites everyone else's rates with a conversion base that is not theirs. A user whose main currency is USD ends up with rates derived from another user's EUR base, and every converted amount they see is wrong until they trigger a manual refresh.

The manual refresh endpoint (`endpoints/currency/update_exchange.php`) already scopes its writes to `user_id`, so the two paths disagreed about the same table.

Single-user installations are unaffected, which is presumably why this went unnoticed.

## The fix

```php
$updateQuery = "UPDATE currencies SET rate = :rate WHERE code = :code AND user_id = :userId";
```

Four lines, including the bind and a short comment.

## About the tests

The fix itself is one condition; the guarantee is what matters. I added a small test suite so a rate write that forgets the user filter fails a test instead of reaching production:

- two cases showing scoped and unscoped updates against a real schema, so the consequence is visible rather than asserted
- one case that scans the rate-update statements in the code base and fails if any of them is missing the user filter

I verified the third case actually catches the regression by reverting the fix — it fails, and passes again once restored.

The harness has no Composer or external dependency, matching the way Wallos vendors its libraries. It runs in a throwaway container, so no local PHP is needed:

```bash
dev/test.sh                          # all cases (podman)
CONTAINER_ENGINE=docker dev/test.sh  # or docker
```

It builds the schema by running `endpoints/cronjobs/createdatabase.php` and the migration chain inside a temporary copy of the tree, so cases exercise the schema the application actually produces rather than a hand-written approximation.

If you would prefer the fix without the test infrastructure, I am happy to split this into two PRs — the fix is the part that matters and I did not want to send it without a way to prove it.
