### PR TITLE
perf: refresh exchange rates in one transaction with one prepared statement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,18 @@ We welcome contributions from the community and look forward to working with you
 
 4.  **Make your changes:** Implement your feature or bug fix.
 5.  **Test your changes:** Ensure that your changes work as expected.
+
+    Wallos has a small test suite in `tests/`. It needs no Composer or local PHP
+    installation — it runs in a throwaway container:
+
+    ```bash
+    dev/test.sh             # all cases
+    dev/test.sh currency    # only cases matching "currency"
+    ```
+
+    Use `CONTAINER_ENGINE=docker dev/test.sh` if you prefer Docker over Podman.
+    Tests build the real schema by running `createdatabase.php` and the
+    migration chain, so they exercise the schema the application produces.
 6.  **Commit your changes:** Commit your changes with a clear and concise message:
 
     ```bash

--- a/api/subscriptions/get_ical_feed.php
+++ b/api/subscriptions/get_ical_feed.php
@@ -9,6 +9,7 @@ It returns a downloadable VCAL file with the active subscriptions
 */
 
 require_once '../../includes/connect_endpoint.php';
+require_once '../../includes/currency_rates.php';
 require_once '../../includes/ical_helper.php';
 
 header('Content-Type: application/json; charset=UTF-8');
@@ -29,18 +30,7 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" || $_SERVER["REQUEST_METHOD"] === "GET
 
     function getPriceConverted($price, $currency, $database)
     {
-        $query = "SELECT rate FROM currencies WHERE id = :currency";
-        $stmt = $database->prepare($query);
-        $stmt->bindParam(':currency', $currency, SQLITE3_INTEGER);
-        $result = $stmt->execute();
-
-        $exchangeRate = $result->fetchArray(SQLITE3_ASSOC);
-        if ($exchangeRate === false) {
-            return $price;
-        } else {
-            $fromRate = $exchangeRate['rate'];
-            return $price / $fromRate;
-        }
+        return wallos_convert_price($price, $currency, $database);
     }
 
     // Get user from API key

--- a/api/subscriptions/get_subscription.php
+++ b/api/subscriptions/get_subscription.php
@@ -47,6 +47,7 @@ Example response:
 */
 
 require_once '../../includes/connect_endpoint.php';
+require_once '../../includes/currency_rates.php';
 
 header('Content-Type: application/json; charset=UTF-8');
 
@@ -138,16 +139,12 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" || $_SERVER["REQUEST_METHOD"] === "GET
         $canConvertCurrency = !empty($lastExchangeUpdate['date']);
 
         if ($canConvertCurrency) {
-            $currSql = "SELECT rate FROM currencies WHERE id = :currencyId AND user_id = :userId";
-            $currStmt = $db->prepare($currSql);
-            $currStmt->bindValue(':currencyId', $subscription['currency_id'], SQLITE3_INTEGER);
-            $currStmt->bindValue(':userId', $userId, SQLITE3_INTEGER);
-            $currResult = $currStmt->execute();
-            $subCurrency = $currResult->fetchArray(SQLITE3_ASSOC);
-
-            if ($subCurrency) {
-                $subscription['price'] = $subscription['price'] / $subCurrency['rate'];
-            }
+            $subscription['price'] = wallos_convert_price(
+                $subscription['price'],
+                $subscription['currency_id'],
+                $db,
+                $userId
+            );
         }
     }
 

--- a/api/subscriptions/get_subscriptions.php
+++ b/api/subscriptions/get_subscriptions.php
@@ -93,6 +93,7 @@ Example response:
 */
 
 require_once '../../includes/connect_endpoint.php';
+require_once '../../includes/currency_rates.php';
 
 header('Content-Type: application/json; charset=UTF-8');
 
@@ -110,17 +111,7 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" || $_SERVER["REQUEST_METHOD"] === "GET
 
     function getPriceConverted($price, $currency, $database)
     {
-        $query = "SELECT rate FROM currencies WHERE id = :currency";
-        $stmt = $database->prepare($query);
-        $stmt->bindParam(':currency', $currency, SQLITE3_INTEGER);
-        $result = $stmt->execute();
-        $exchangeRate = $result->fetchArray(SQLITE3_ASSOC);
-        if ($exchangeRate === false) {
-            return $price;
-        } else {
-            $fromRate = $exchangeRate['rate'];
-            return $price / $fromRate;
-        }
+        return wallos_convert_price($price, $currency, $database);
     }
 
     // Get user from API key

--- a/calendar.php
+++ b/calendar.php
@@ -1,21 +1,10 @@
 <?php
 require_once 'includes/header.php';
+require_once 'includes/currency_rates.php';
 
 function getPriceConverted($price, $currency, $database, $userId)
 {
-  $query = "SELECT rate FROM currencies WHERE id = :currency AND user_id = :userId";
-  $stmt = $database->prepare($query);
-  $stmt->bindParam(':currency', $currency, SQLITE3_INTEGER);
-  $stmt->bindParam(':userId', $userId, SQLITE3_INTEGER);
-  $result = $stmt->execute();
-
-  $exchangeRate = $result->fetchArray(SQLITE3_ASSOC);
-  if ($exchangeRate === false) {
-    return $price;
-  } else {
-    $fromRate = $exchangeRate['rate'];
-    return $price / $fromRate;
-  }
+  return wallos_convert_price($price, $currency, $database, $userId);
 }
 
 // Get budget from user table

--- a/dev/test.sh
+++ b/dev/test.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Runs the test suite in a throwaway PHP container, so no local PHP is needed.
+#
+#   dev/test.sh              every case
+#   dev/test.sh currency     cases matching "currency"
+
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+ENGINE=${CONTAINER_ENGINE:-podman}
+
+exec "$ENGINE" run --rm \
+    -v "$ROOT":/var/www/html:Z \
+    -w /var/www/html \
+    docker.io/library/php:8.3-cli \
+    php tests/run.php "$@"

--- a/endpoints/cronjobs/storetotalyearlycost.php
+++ b/endpoints/cronjobs/storetotalyearlycost.php
@@ -1,6 +1,7 @@
 <?php
 require_once 'validate.php';
 require_once __DIR__ . '/../../includes/connect_endpoint_crontabs.php';
+require_once __DIR__ . '/../../includes/currency_rates.php';
 
 require 'settimezone.php';
 
@@ -32,19 +33,7 @@ function getPricePerMonth($cycle, $frequency, $price)
 
 function getPriceConverted($price, $currency, $database, $userId)
 {
-  $query = "SELECT rate FROM currencies WHERE id = :currency AND user_id = :userId";
-  $stmt = $database->prepare($query);
-  $stmt->bindParam(':currency', $currency, SQLITE3_INTEGER);
-  $stmt->bindParam(':userId', $userId, SQLITE3_INTEGER);
-  $result = $stmt->execute();
-
-  $exchangeRate = $result->fetchArray(SQLITE3_ASSOC);
-  if ($exchangeRate === false) {
-    return $price;
-  } else {
-    $fromRate = $exchangeRate['rate'];
-    return $price / $fromRate;
-  }
+  return wallos_convert_price($price, $currency, $database, $userId);
 }
 
 // Get all users

--- a/endpoints/cronjobs/updateexchange.php
+++ b/endpoints/cronjobs/updateexchange.php
@@ -73,10 +73,13 @@ while ($userToUpdateExchange = $usersToUpdateExchange->fetchArray(SQLITE3_ASSOC)
                     } else {
                         $exchangeRate = $rate / $mainCurrencyToEUR;
                     }
-                    $updateQuery = "UPDATE currencies SET rate = :rate WHERE code = :code";
+                    // Every user has their own currency rows, converted against their own
+                    // main currency, so the write must be scoped to the user being refreshed.
+                    $updateQuery = "UPDATE currencies SET rate = :rate WHERE code = :code AND user_id = :userId";
                     $updateStmt = $db->prepare($updateQuery);
                     $updateStmt->bindParam(':rate', $exchangeRate, SQLITE3_TEXT);
                     $updateStmt->bindParam(':code', $currencyCode, SQLITE3_TEXT);
+                    $updateStmt->bindParam(':userId', $userId, SQLITE3_INTEGER);
                     $updateResult = $updateStmt->execute();
 
                     if (!$updateResult) {

--- a/endpoints/cronjobs/updateexchange.php
+++ b/endpoints/cronjobs/updateexchange.php
@@ -67,40 +67,59 @@ while ($userToUpdateExchange = $usersToUpdateExchange->fetchArray(SQLITE3_ASSOC)
             $mainCurrencyToEUR = $apiData['rates'][$mainCurrencyCode];
 
             if ($apiData !== null && isset($apiData['rates'])) {
+                // One user's rates and their refresh date are one unit of work:
+                // a failure halfway through would otherwise leave some rows
+                // converted against the new base and some against the old one.
+                $db->exec('BEGIN');
+
+                // Every user has their own currency rows, converted against their own
+                // main currency, so the write must be scoped to the user being refreshed.
+                $updateQuery = "UPDATE currencies SET rate = :rate WHERE code = :code AND user_id = :userId";
+                $updateStmt = $db->prepare($updateQuery);
+                $updateFailed = false;
+
                 foreach ($apiData['rates'] as $currencyCode => $rate) {
                     if ($currencyCode === $mainCurrencyCode) {
                         $exchangeRate = 1.0;
                     } else {
                         $exchangeRate = $rate / $mainCurrencyToEUR;
                     }
-                    // Every user has their own currency rows, converted against their own
-                    // main currency, so the write must be scoped to the user being refreshed.
-                    $updateQuery = "UPDATE currencies SET rate = :rate WHERE code = :code AND user_id = :userId";
-                    $updateStmt = $db->prepare($updateQuery);
-                    $updateStmt->bindParam(':rate', $exchangeRate, SQLITE3_TEXT);
-                    $updateStmt->bindParam(':code', $currencyCode, SQLITE3_TEXT);
-                    $updateStmt->bindParam(':userId', $userId, SQLITE3_INTEGER);
+
+                    $updateStmt->bindValue(':rate', $exchangeRate, SQLITE3_TEXT);
+                    $updateStmt->bindValue(':code', $currencyCode, SQLITE3_TEXT);
+                    $updateStmt->bindValue(':userId', $userId, SQLITE3_INTEGER);
                     $updateResult = $updateStmt->execute();
+                    $updateStmt->reset();
 
                     if (!$updateResult) {
                         echo "Error updating rate for currency: $currencyCode <br />";
+                        $updateFailed = true;
+                        break;
                     }
                 }
-                $currentDate = new DateTime();
-                $formattedDate = $currentDate->format('Y-m-d');
 
-                $deleteQuery = "DELETE FROM last_exchange_update WHERE user_id = :userId";
-                $deleteStmt = $db->prepare($deleteQuery);
-                $deleteStmt->bindParam(':userId', $userId, SQLITE3_INTEGER);
-                $deleteResult = $deleteStmt->execute();
+                if ($updateFailed) {
+                    $db->exec('ROLLBACK');
+                    echo "Exchange rates update rolled back for this user.<br />";
+                } else {
+                    $currentDate = new DateTime();
+                    $formattedDate = $currentDate->format('Y-m-d');
 
-                $query = "INSERT INTO last_exchange_update (date, user_id) VALUES (:formattedDate, :userId)";
-                $stmt = $db->prepare($query);
-                $stmt->bindParam(':formattedDate', $formattedDate, SQLITE3_TEXT);
-                $stmt->bindParam(':userId', $userId, SQLITE3_INTEGER);
-                $result = $stmt->execute();
+                    $deleteQuery = "DELETE FROM last_exchange_update WHERE user_id = :userId";
+                    $deleteStmt = $db->prepare($deleteQuery);
+                    $deleteStmt->bindParam(':userId', $userId, SQLITE3_INTEGER);
+                    $deleteResult = $deleteStmt->execute();
 
-                echo "Rates updated successfully!<br />";
+                    $query = "INSERT INTO last_exchange_update (date, user_id) VALUES (:formattedDate, :userId)";
+                    $stmt = $db->prepare($query);
+                    $stmt->bindParam(':formattedDate', $formattedDate, SQLITE3_TEXT);
+                    $stmt->bindParam(':userId', $userId, SQLITE3_INTEGER);
+                    $result = $stmt->execute();
+
+                    $db->exec('COMMIT');
+
+                    echo "Rates updated successfully!<br />";
+                }
             }
         } else {
             echo "Exchange rates update skipped. No fixer.io api key provided<br />";

--- a/endpoints/currency/update_exchange.php
+++ b/endpoints/currency/update_exchange.php
@@ -97,34 +97,54 @@ if ($result) {
         $mainCurrencyToEUR = $apiData['rates'][$mainCurrencyCode];
 
         if ($apiData !== null && isset($apiData['rates'])) {
+            // The rates and the refresh date are one unit of work: a failure
+            // halfway through would otherwise leave some rows converted against
+            // the new base and some against the old one.
+            $db->exec('BEGIN');
+
+            $updateQuery = "UPDATE currencies SET rate = :rate WHERE code = :code AND user_id = :userId";
+            $updateStmt = $db->prepare($updateQuery);
+            $updateFailed = false;
+
             foreach ($apiData['rates'] as $currencyCode => $rate) {
                 if ($currencyCode === $mainCurrencyCode) {
                     $exchangeRate = 1.0;
                 } else {
                     $exchangeRate = $rate / $mainCurrencyToEUR;
                 }
-                $updateQuery = "UPDATE currencies SET rate = :rate WHERE code = :code AND user_id = :userId";
-                $updateStmt = $db->prepare($updateQuery);
-                $updateStmt->bindParam(':rate', $exchangeRate, SQLITE3_TEXT);
-                $updateStmt->bindParam(':code', $currencyCode, SQLITE3_TEXT);
-                $updateStmt->bindParam(':userId', $userId, SQLITE3_INTEGER);
+
+                $updateStmt->bindValue(':rate', $exchangeRate, SQLITE3_TEXT);
+                $updateStmt->bindValue(':code', $currencyCode, SQLITE3_TEXT);
+                $updateStmt->bindValue(':userId', $userId, SQLITE3_INTEGER);
                 $updateResult = $updateStmt->execute();
+                $updateStmt->reset();
 
                 if (!$updateResult) {
                     echo "Error updating rate for currency: $currencyCode";
+                    $updateFailed = true;
+                    break;
                 }
             }
-            $currentDate = new DateTime();
-            $formattedDate = $currentDate->format('Y-m-d');
 
-            $updateQuery = "UPDATE last_exchange_update SET date = :formattedDate WHERE user_id = :userId";
-            $updateStmt = $db->prepare($updateQuery);
-            $updateStmt->bindParam(':formattedDate', $formattedDate, SQLITE3_TEXT);
-            $updateStmt->bindParam(':userId', $userId, SQLITE3_INTEGER);
-            $updateResult = $updateStmt->execute();
+            if ($updateFailed) {
+                $db->exec('ROLLBACK');
+                $db->close();
+                echo "Exchange rates update rolled back.";
+            } else {
+                $currentDate = new DateTime();
+                $formattedDate = $currentDate->format('Y-m-d');
 
-            $db->close();
-            echo "Rates updated successfully!";
+                $updateQuery = "UPDATE last_exchange_update SET date = :formattedDate WHERE user_id = :userId";
+                $updateStmt = $db->prepare($updateQuery);
+                $updateStmt->bindParam(':formattedDate', $formattedDate, SQLITE3_TEXT);
+                $updateStmt->bindParam(':userId', $userId, SQLITE3_INTEGER);
+                $updateResult = $updateStmt->execute();
+
+                $db->exec('COMMIT');
+
+                $db->close();
+                echo "Rates updated successfully!";
+            }
         }
     } else {
         echo "Exchange rates update skipped. No fixer.io api key provided";

--- a/includes/budget_period_calculations.php
+++ b/includes/budget_period_calculations.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once __DIR__ . '/currency_rates.php';
+
 if (!function_exists('sanitizeBudgetPeriodType')) {
     function sanitizeBudgetPeriodType($periodType)
     {
@@ -256,18 +258,7 @@ if (!function_exists('getSubscriptionOccurrencesInRange')) {
 if (!function_exists('convertPriceToMainCurrency')) {
     function convertPriceToMainCurrency($price, $currencyId, SQLite3 $database, $userId)
     {
-        $query = "SELECT rate FROM currencies WHERE id = :currencyId AND user_id = :userId";
-        $stmt = $database->prepare($query);
-        $stmt->bindValue(':currencyId', $currencyId, SQLITE3_INTEGER);
-        $stmt->bindValue(':userId', $userId, SQLITE3_INTEGER);
-        $result = $stmt->execute();
-        $exchangeRate = $result ? $result->fetchArray(SQLITE3_ASSOC) : false;
-
-        if ($exchangeRate === false || empty($exchangeRate['rate'])) {
-            return (float) $price;
-        }
-
-        return (float) $price / (float) $exchangeRate['rate'];
+        return wallos_convert_price($price, $currencyId, $database, $userId);
     }
 }
 

--- a/includes/currency_rates.php
+++ b/includes/currency_rates.php
@@ -1,0 +1,85 @@
+<?php
+/*
+  Exchange-rate lookups for price conversion.
+
+  Rates change once a day at most, but conversion happens once per subscription,
+  once per statistics row and once per calendar entry. Looking them up per row
+  turns rendering a list into one query per item, so they are loaded once and
+  answered from memory for the rest of the request.
+*/
+
+/**
+ * Returns the exchange rates as [currency_id => rate].
+ *
+ * Passing a user id restricts the map to that user's currencies, matching the
+ * lookups that filtered by user; omitting it covers every currency, matching
+ * the lookups that resolved a currency by id alone.
+ *
+ * The map is cached per database connection, so a second connection — a test,
+ * or a job that reopens the database — never sees another connection's rates.
+ *
+ * @param SQLite3  $db
+ * @param int|null $userId
+ * @return array<int, float>
+ */
+function wallos_currency_rates($db, $userId = null)
+{
+    // Keyed by the connection object itself: an id would be reused once a
+    // connection is closed, and the next one would inherit stale rates.
+    static $cache = null;
+
+    if ($cache === null) {
+        $cache = new WeakMap();
+    }
+
+    $key = $userId === null ? 'all' : (int) $userId;
+    $connectionRates = $cache[$db] ?? [];
+
+    if (isset($connectionRates[$key])) {
+        return $connectionRates[$key];
+    }
+
+    $rates = [];
+
+    if ($userId === null) {
+        $stmt = $db->prepare('SELECT id, rate FROM currencies');
+    } else {
+        $stmt = $db->prepare('SELECT id, rate FROM currencies WHERE user_id = :userId');
+        $stmt->bindValue(':userId', $userId, SQLITE3_INTEGER);
+    }
+
+    $result = $stmt ? $stmt->execute() : false;
+
+    while ($result && $row = $result->fetchArray(SQLITE3_ASSOC)) {
+        $rates[(int) $row['id']] = (float) $row['rate'];
+    }
+
+    $connectionRates[$key] = $rates;
+    $cache[$db] = $connectionRates;
+
+    return $rates;
+}
+
+/**
+ * Converts a price from the given currency into the user's main currency.
+ *
+ * An unknown currency or a missing rate leaves the price untouched, which is
+ * what the per-row lookups did when they found no row.
+ *
+ * @param float|int|string $price
+ * @param int              $currencyId
+ * @param SQLite3          $db
+ * @param int|null         $userId
+ * @return float
+ */
+function wallos_convert_price($price, $currencyId, $db, $userId = null)
+{
+    $rates = wallos_currency_rates($db, $userId);
+    $rate = $rates[(int) $currencyId] ?? null;
+
+    if (empty($rate)) {
+        return (float) $price;
+    }
+
+    return (float) $price / $rate;
+}

--- a/includes/list_subscriptions.php
+++ b/includes/list_subscriptions.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once 'i18n/getlang.php';
+require_once __DIR__ . '/currency_rates.php';
 
 function getBillingCycle($cycle, $frequency, $i18n)
 {
@@ -84,18 +85,7 @@ function getPricePerMonth($cycle, $frequency, $price)
 
 function getPriceConverted($price, $currency, $database)
 {
-    $query = "SELECT rate FROM currencies WHERE id = :currency";
-    $stmt = $database->prepare($query);
-    $stmt->bindParam(':currency', $currency, SQLITE3_INTEGER);
-    $result = $stmt->execute();
-
-    $exchangeRate = $result->fetchArray(SQLITE3_ASSOC);
-    if ($exchangeRate === false) {
-        return $price;
-    } else {
-        $fromRate = $exchangeRate['rate'];
-        return $price / $fromRate;
-    }
+    return wallos_convert_price($price, $currency, $database);
 }
 
 function formatPrice($price, $currencyCode, $currencies)

--- a/includes/stats_calculations.php
+++ b/includes/stats_calculations.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/budget_period_calculations.php';
+require_once __DIR__ . '/currency_rates.php';
 
 function getPricePerMonth($cycle, $frequency, $price)
 {
@@ -23,19 +24,7 @@ function getPricePerMonth($cycle, $frequency, $price)
 
 function getPriceConverted($price, $currency, $database, $userId)
 {
-    $query = "SELECT rate FROM currencies WHERE id = :currency AND user_id = :userId";
-    $stmt = $database->prepare($query);
-    $stmt->bindParam(':currency', $currency, SQLITE3_INTEGER);
-    $stmt->bindParam(':userId', $userId, SQLITE3_INTEGER);
-    $result = $stmt->execute();
-
-    $exchangeRate = $result->fetchArray(SQLITE3_ASSOC);
-    if ($exchangeRate === false) {
-        return $price;
-    } else {
-        $fromRate = $exchangeRate['rate'];
-        return $price / $fromRate;
-    }
+    return wallos_convert_price($price, $currency, $database, $userId);
 }
 
 // Get categories

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,256 @@
+<?php
+/*
+  Minimal test harness for Wallos.
+
+  Wallos vendors its libraries instead of using Composer, so the tests follow
+  the same principle: no external dependency, just PHP and the SQLite
+  extension the application already requires.
+
+  A test file registers cases with wallos_test() and asserts with the assert_*
+  helpers. tests/run.php discovers and runs them.
+*/
+
+define('WALLOS_ROOT', dirname(__DIR__));
+define('WALLOS_TEST_TMP', sys_get_temp_dir() . '/wallos-tests');
+
+$GLOBALS['wallos_tests'] = [];
+$GLOBALS['wallos_test_failures'] = [];
+$GLOBALS['wallos_test_assertions'] = 0;
+$GLOBALS['wallos_test_current'] = null;
+
+/**
+ * Registers one test case.
+ *
+ * @param string   $name
+ * @param callable $body
+ */
+function wallos_test($name, callable $body)
+{
+    $GLOBALS['wallos_tests'][] = ['name' => $name, 'body' => $body];
+}
+
+function wallos_test_fail($message)
+{
+    $GLOBALS['wallos_test_failures'][] = [
+        'test' => $GLOBALS['wallos_test_current'],
+        'message' => $message,
+    ];
+}
+
+function assert_true($condition, $message)
+{
+    $GLOBALS['wallos_test_assertions']++;
+
+    if (!$condition) {
+        wallos_test_fail($message);
+    }
+}
+
+function assert_same($expected, $actual, $message)
+{
+    $GLOBALS['wallos_test_assertions']++;
+
+    if ($expected !== $actual) {
+        wallos_test_fail(sprintf(
+            '%s (expected %s, got %s)',
+            $message,
+            var_export($expected, true),
+            var_export($actual, true)
+        ));
+    }
+}
+
+function assert_equals($expected, $actual, $message)
+{
+    $GLOBALS['wallos_test_assertions']++;
+
+    if ($expected != $actual) {
+        wallos_test_fail(sprintf(
+            '%s (expected %s, got %s)',
+            $message,
+            var_export($expected, true),
+            var_export($actual, true)
+        ));
+    }
+}
+
+function assert_contains($needle, $haystack, $message)
+{
+    $GLOBALS['wallos_test_assertions']++;
+
+    if (strpos((string) $haystack, (string) $needle) === false) {
+        wallos_test_fail($message . ' (missing: ' . $needle . ')');
+    }
+}
+
+function assert_not_contains($needle, $haystack, $message)
+{
+    $GLOBALS['wallos_test_assertions']++;
+
+    if (strpos((string) $haystack, (string) $needle) !== false) {
+        wallos_test_fail($message . ' (unexpectedly present: ' . $needle . ')');
+    }
+}
+
+/**
+ * Builds the real application schema once per run by running the same
+ * createdatabase.php and migration chain the container startup uses, then
+ * hands out a fresh copy of it per test.
+ *
+ * The application resolves its database path relative to its own directory, so
+ * the schema is built inside a throwaway copy of the source tree rather than in
+ * the working copy.
+ *
+ * @return string Path to the freshly copied database.
+ */
+function wallos_test_database()
+{
+    static $template = null;
+
+    if ($template === null) {
+        $sandbox = WALLOS_TEST_TMP . '/sandbox';
+
+        if (!is_dir($sandbox)) {
+            mkdir($sandbox, 0700, true);
+            foreach (['endpoints/cronjobs', 'includes', 'migrations', 'db'] as $directory) {
+                mkdir($sandbox . '/' . $directory, 0700, true);
+            }
+
+            foreach (glob(WALLOS_ROOT . '/migrations/*.php') as $migration) {
+                copy($migration, $sandbox . '/migrations/' . basename($migration));
+            }
+            copy(WALLOS_ROOT . '/endpoints/cronjobs/createdatabase.php', $sandbox . '/endpoints/cronjobs/createdatabase.php');
+            copy(WALLOS_ROOT . '/includes/run_migrations.php', $sandbox . '/includes/run_migrations.php');
+        }
+
+        $databaseFile = $sandbox . '/db/wallos.db';
+
+        if (!file_exists($databaseFile)) {
+            // Both scripts print progress and resolve their paths from __DIR__,
+            // which is why they run inside the sandbox copy.
+            ob_start();
+            require $sandbox . '/endpoints/cronjobs/createdatabase.php';
+            $db = new SQLite3($databaseFile);
+            $db->busyTimeout(5000);
+            require $sandbox . '/includes/run_migrations.php';
+            $db->close();
+            ob_end_clean();
+        }
+
+        $template = $databaseFile;
+    }
+
+    $copy = WALLOS_TEST_TMP . '/case-' . uniqid('', true) . '.db';
+    copy($template, $copy);
+
+    return $copy;
+}
+
+/**
+ * Opens a fresh database with the full application schema.
+ *
+ * @return SQLite3
+ */
+function wallos_test_open_database()
+{
+    $db = new SQLite3(wallos_test_database());
+    $db->busyTimeout(5000);
+
+    return $db;
+}
+
+/**
+ * SQLite3 wrapper that counts statements, so tests can assert that a code path
+ * does not issue one query per row.
+ */
+class WallosCountingDatabase extends SQLite3
+{
+    public $queryCount = 0;
+
+    public function prepare($query): SQLite3Stmt|false
+    {
+        $this->queryCount++;
+
+        return parent::prepare($query);
+    }
+
+    public function query($query): SQLite3Result|false
+    {
+        $this->queryCount++;
+
+        return parent::query($query);
+    }
+
+    public function querySingle($query, $entireRow = false): mixed
+    {
+        $this->queryCount++;
+
+        return parent::querySingle($query, $entireRow);
+    }
+
+    public function resetQueryCount()
+    {
+        $this->queryCount = 0;
+    }
+}
+
+/**
+ * @return WallosCountingDatabase
+ */
+function wallos_test_open_counting_database()
+{
+    $db = new WallosCountingDatabase(wallos_test_database());
+    $db->busyTimeout(5000);
+
+    return $db;
+}
+
+/**
+ * Inserts a user together with the currency rows Wallos creates alongside it.
+ *
+ * @param SQLite3 $db
+ * @param int     $id
+ * @param string  $username
+ */
+function wallos_test_create_user($db, $id, $username)
+{
+    $stmt = $db->prepare("INSERT INTO user (id, username, email, password, main_currency) VALUES (:id, :username, :email, 'x', 1)");
+    $stmt->bindValue(':id', $id, SQLITE3_INTEGER);
+    $stmt->bindValue(':username', $username, SQLITE3_TEXT);
+    $stmt->bindValue(':email', $username . '@example.com', SQLITE3_TEXT);
+    $stmt->execute();
+
+    // createdatabase.php seeds a default currency list; the fixture replaces it
+    // so a test can reason about exactly two rows per user.
+    $stmt = $db->prepare('DELETE FROM currencies WHERE user_id = :userId');
+    $stmt->bindValue(':userId', $id, SQLITE3_INTEGER);
+    $stmt->execute();
+
+    foreach ([['EUR', 'Euro', 1.0], ['USD', 'US Dollar', 1.1]] as $index => $currency) {
+        $stmt = $db->prepare('INSERT INTO currencies (id, name, symbol, code, rate, user_id) VALUES (:id, :name, :symbol, :code, :rate, :userId)');
+        $stmt->bindValue(':id', wallos_test_currency_id($id, $index), SQLITE3_INTEGER);
+        $stmt->bindValue(':name', $currency[1], SQLITE3_TEXT);
+        $stmt->bindValue(':symbol', $currency[0] === 'EUR' ? "\u{20AC}" : '$', SQLITE3_TEXT);
+        $stmt->bindValue(':code', $currency[0], SQLITE3_TEXT);
+        $stmt->bindValue(':rate', $currency[2], SQLITE3_FLOAT);
+        $stmt->bindValue(':userId', $id, SQLITE3_INTEGER);
+        $stmt->execute();
+    }
+
+    $stmt = $db->prepare('UPDATE user SET main_currency = :currencyId WHERE id = :id');
+    $stmt->bindValue(':currencyId', wallos_test_currency_id($id, 0), SQLITE3_INTEGER);
+    $stmt->bindValue(':id', $id, SQLITE3_INTEGER);
+    $stmt->execute();
+}
+
+/**
+ * Fixture currency ids live above the seeded default list so they never clash.
+ *
+ * @param int $userId
+ * @param int $index   0 = EUR (main currency), 1 = USD
+ * @return int
+ */
+function wallos_test_currency_id($userId, $index)
+{
+    return 9000 + ($userId * 10) + $index;
+}

--- a/tests/cases/currency_rates_test.php
+++ b/tests/cases/currency_rates_test.php
@@ -1,0 +1,126 @@
+<?php
+/*
+  Price conversion must not issue one query per converted row.
+*/
+
+require_once WALLOS_ROOT . '/includes/currency_rates.php';
+
+/**
+ * @param SQLite3 $db
+ */
+function currency_rates_fixture($db)
+{
+    wallos_test_create_user($db, 1, 'alice');
+    wallos_test_create_user($db, 2, 'bob');
+
+    // Alice: EUR at 1.0 (main), USD at 1.1. Bob: both at 2.5.
+    $stmt = $db->prepare('UPDATE currencies SET rate = 2.5 WHERE user_id = 2');
+    $stmt->execute();
+}
+
+wallos_test('converting many prices issues one query, not one per price', function () {
+    $db = wallos_test_open_counting_database();
+    currency_rates_fixture($db);
+
+    $usd = wallos_test_currency_id(1, 1);
+    $db->resetQueryCount();
+
+    for ($i = 0; $i < 50; $i++) {
+        wallos_convert_price(11.0, $usd, $db, 1);
+    }
+
+    assert_same(1, $db->queryCount,
+        '50 conversions should need one rate query (got ' . $db->queryCount . ')');
+
+    $db->close();
+});
+
+wallos_test('conversion produces the same result as a direct rate lookup', function () {
+    $db = wallos_test_open_database();
+    currency_rates_fixture($db);
+
+    $usd = wallos_test_currency_id(1, 1);
+
+    $stmt = $db->prepare('SELECT rate FROM currencies WHERE id = :id');
+    $stmt->bindValue(':id', $usd, SQLITE3_INTEGER);
+    $rate = (float) $stmt->execute()->fetchArray(SQLITE3_ASSOC)['rate'];
+
+    assert_same(11.0 / $rate, wallos_convert_price(11.0, $usd, $db, 1),
+        'the converted value is unchanged');
+
+    $db->close();
+});
+
+wallos_test('an unknown currency leaves the price untouched', function () {
+    $db = wallos_test_open_database();
+    currency_rates_fixture($db);
+
+    assert_same(9.99, wallos_convert_price(9.99, 999999, $db, 1),
+        'a missing currency behaves like a lookup that found no row');
+
+    $db->close();
+});
+
+wallos_test('a zero rate leaves the price untouched', function () {
+    // The per-row lookups divided by whatever they found; a zero rate raises a
+    // division error in PHP 8. Treating it as "no usable rate" is safer and
+    // matches what the budget calculation already did.
+    $db = wallos_test_open_database();
+    currency_rates_fixture($db);
+
+    $usd = wallos_test_currency_id(1, 1);
+    $stmt = $db->prepare('UPDATE currencies SET rate = 0 WHERE id = :id');
+    $stmt->bindValue(':id', $usd, SQLITE3_INTEGER);
+    $stmt->execute();
+
+    assert_same(9.99, wallos_convert_price(9.99, $usd, $db, 1),
+        'a zero rate leaves the price untouched instead of failing');
+
+    $db->close();
+});
+
+wallos_test('rates are scoped to the requested user', function () {
+    $db = wallos_test_open_database();
+    currency_rates_fixture($db);
+
+    $aliceUsd = wallos_test_currency_id(1, 1);
+    $bobUsd = wallos_test_currency_id(2, 1);
+
+    assert_same(11.0 / 1.1, wallos_convert_price(11.0, $aliceUsd, $db, 1), "alice's rate is used");
+    assert_same(11.0 / 2.5, wallos_convert_price(11.0, $bobUsd, $db, 2), "bob's rate is used");
+
+    // A currency belonging to another user is not visible in a scoped map.
+    assert_same(11.0, wallos_convert_price(11.0, $bobUsd, $db, 1),
+        "bob's currency is not resolved for alice");
+
+    $db->close();
+});
+
+wallos_test('the unscoped map resolves any currency by id', function () {
+    // Matches the lookups that resolved a currency by id alone.
+    $db = wallos_test_open_database();
+    currency_rates_fixture($db);
+
+    assert_same(11.0 / 2.5, wallos_convert_price(11.0, wallos_test_currency_id(2, 1), $db),
+        'without a user, any currency id resolves');
+
+    $db->close();
+});
+
+wallos_test('two connections do not share a rate map', function () {
+    $first = wallos_test_open_database();
+    currency_rates_fixture($first);
+
+    $second = wallos_test_open_database();
+    currency_rates_fixture($second);
+    $stmt = $second->prepare('UPDATE currencies SET rate = 4.0 WHERE user_id = 1');
+    $stmt->execute();
+
+    $usd = wallos_test_currency_id(1, 1);
+
+    assert_same(11.0 / 1.1, wallos_convert_price(11.0, $usd, $first, 1), 'the first connection keeps its rates');
+    assert_same(11.0 / 4.0, wallos_convert_price(11.0, $usd, $second, 1), 'the second connection sees its own');
+
+    $first->close();
+    $second->close();
+});

--- a/tests/cases/currency_refresh_test.php
+++ b/tests/cases/currency_refresh_test.php
@@ -1,0 +1,110 @@
+<?php
+/*
+  A rate refresh writes every rate of one user or none of them.
+
+  Rates are only comparable when they share a conversion base. A refresh that
+  stops halfway leaves some rows against the new base and some against the old
+  one, which is worse than not refreshing at all: the numbers look plausible
+  and are wrong.
+*/
+
+/**
+ * @param SQLite3 $db
+ * @param int     $userId
+ * @param string  $code
+ * @return float
+ */
+function refresh_rate($db, $userId, $code)
+{
+    $stmt = $db->prepare('SELECT rate FROM currencies WHERE user_id = :userId AND code = :code');
+    $stmt->bindValue(':userId', $userId, SQLITE3_INTEGER);
+    $stmt->bindValue(':code', $code, SQLITE3_TEXT);
+    $row = $stmt->execute()->fetchArray(SQLITE3_ASSOC);
+
+    return $row ? (float) $row['rate'] : 0.0;
+}
+
+wallos_test('an interrupted refresh leaves the previous rates', function () {
+    $db = wallos_test_open_database();
+    wallos_test_create_user($db, 1, 'alice');
+
+    $before = [refresh_rate($db, 1, 'EUR'), refresh_rate($db, 1, 'USD')];
+
+    $db->exec('BEGIN');
+
+    $stmt = $db->prepare('UPDATE currencies SET rate = :rate WHERE code = :code AND user_id = :userId');
+    $stmt->bindValue(':rate', 7.0, SQLITE3_TEXT);
+    $stmt->bindValue(':code', 'EUR', SQLITE3_TEXT);
+    $stmt->bindValue(':userId', 1, SQLITE3_INTEGER);
+    $stmt->execute();
+    $stmt->reset();
+
+    // The provider response breaks off here: the second currency never lands.
+    $db->exec('ROLLBACK');
+
+    assert_same($before[0], refresh_rate($db, 1, 'EUR'), 'the first rate is restored');
+    assert_same($before[1], refresh_rate($db, 1, 'USD'), 'the second rate is unchanged');
+
+    $db->close();
+});
+
+wallos_test('a completed refresh commits every rate together', function () {
+    $db = wallos_test_open_database();
+    wallos_test_create_user($db, 1, 'alice');
+
+    $db->exec('BEGIN');
+
+    $stmt = $db->prepare('UPDATE currencies SET rate = :rate WHERE code = :code AND user_id = :userId');
+    foreach (['EUR' => 1.0, 'USD' => 3.0] as $code => $rate) {
+        $stmt->bindValue(':rate', $rate, SQLITE3_TEXT);
+        $stmt->bindValue(':code', $code, SQLITE3_TEXT);
+        $stmt->bindValue(':userId', 1, SQLITE3_INTEGER);
+        $stmt->execute();
+        $stmt->reset();
+    }
+
+    $db->exec('COMMIT');
+
+    assert_same(1.0, refresh_rate($db, 1, 'EUR'), 'the first rate is stored');
+    assert_same(3.0, refresh_rate($db, 1, 'USD'), 'the second rate is stored');
+
+    $db->close();
+});
+
+wallos_test('one prepared statement serves the whole rate loop', function () {
+    $db = wallos_test_open_counting_database();
+    wallos_test_create_user($db, 1, 'alice');
+
+    $db->resetQueryCount();
+
+    $stmt = $db->prepare('UPDATE currencies SET rate = :rate WHERE code = :code AND user_id = :userId');
+    foreach (['EUR', 'USD', 'EUR', 'USD', 'EUR'] as $index => $code) {
+        $stmt->bindValue(':rate', 1.0 + $index, SQLITE3_TEXT);
+        $stmt->bindValue(':code', $code, SQLITE3_TEXT);
+        $stmt->bindValue(':userId', 1, SQLITE3_INTEGER);
+        $stmt->execute();
+        $stmt->reset();
+    }
+
+    assert_same(1, $db->queryCount, 'five writes need one prepare (got ' . $db->queryCount . ')');
+
+    $db->close();
+});
+
+wallos_test('both refresh paths wrap their writes in a transaction', function () {
+    // Structural guard: a future refresh path that autocommits per currency
+    // fails here rather than shipping a half-converted rate set.
+    foreach (['endpoints/cronjobs/updateexchange.php', 'endpoints/currency/update_exchange.php'] as $path) {
+        $source = file_get_contents(WALLOS_ROOT . '/' . $path);
+
+        assert_contains("BEGIN", $source, $path . ' opens a transaction');
+        assert_contains("COMMIT", $source, $path . ' commits it');
+        assert_contains("ROLLBACK", $source, $path . ' rolls back on failure');
+
+        // The prepare must sit outside the loop over the provider rates.
+        $preparePosition = strpos($source, 'UPDATE currencies SET rate');
+        $loopPosition = strpos($source, "foreach (\$apiData['rates']");
+        assert_true($preparePosition !== false && $loopPosition !== false && $preparePosition < $loopPosition,
+            $path . ' prepares the rate update once, before the loop');
+    }
+});

--- a/tests/cases/currency_scope_test.php
+++ b/tests/cases/currency_scope_test.php
@@ -1,0 +1,97 @@
+<?php
+/*
+  Refreshing one user's exchange rates must never touch another user's rows.
+
+  Wallos stores one currency row per user, and each user's rate is derived from
+  their own main currency. A rate update that matches on the currency code alone
+  therefore overwrites other users' rates with a conversion base that is not
+  theirs.
+*/
+
+/**
+ * Seeds two users whose currencies overlap but whose main currency differs.
+ *
+ * @param SQLite3 $db
+ */
+function currency_scope_fixture($db)
+{
+    wallos_test_create_user($db, 1, 'alice');
+    wallos_test_create_user($db, 2, 'bob');
+
+    // Bob's rates are deliberately distinct so any cross-user write is visible.
+    $stmt = $db->prepare('UPDATE currencies SET rate = 2.5 WHERE user_id = 2');
+    $stmt->execute();
+}
+
+/**
+ * @param SQLite3 $db
+ * @param int     $userId
+ * @param string  $code
+ * @return float
+ */
+function currency_scope_rate($db, $userId, $code)
+{
+    $stmt = $db->prepare('SELECT rate FROM currencies WHERE user_id = :userId AND code = :code');
+    $stmt->bindValue(':userId', $userId, SQLITE3_INTEGER);
+    $stmt->bindValue(':code', $code, SQLITE3_TEXT);
+    $result = $stmt->execute();
+    $row = $result ? $result->fetchArray(SQLITE3_ASSOC) : false;
+
+    return $row ? (float) $row['rate'] : 0.0;
+}
+
+wallos_test('rate updates are scoped to one user', function () {
+    $db = wallos_test_open_database();
+    currency_scope_fixture($db);
+
+    $before = currency_scope_rate($db, 2, 'USD');
+
+    // The update statement used by the refresh path.
+    $stmt = $db->prepare('UPDATE currencies SET rate = :rate WHERE code = :code AND user_id = :userId');
+    $stmt->bindValue(':rate', 9.99, SQLITE3_FLOAT);
+    $stmt->bindValue(':code', 'USD', SQLITE3_TEXT);
+    $stmt->bindValue(':userId', 1, SQLITE3_INTEGER);
+    $stmt->execute();
+
+    assert_same(9.99, currency_scope_rate($db, 1, 'USD'), "alice's rate is updated");
+    assert_same($before, currency_scope_rate($db, 2, 'USD'), "bob's rate is untouched");
+
+    $db->close();
+});
+
+wallos_test('an unscoped rate update would corrupt other users', function () {
+    // Guards the regression itself: if this ever stops being true, the scoped
+    // statement above has lost its purpose.
+    $db = wallos_test_open_database();
+    currency_scope_fixture($db);
+
+    $stmt = $db->prepare('UPDATE currencies SET rate = :rate WHERE code = :code');
+    $stmt->bindValue(':rate', 9.99, SQLITE3_FLOAT);
+    $stmt->bindValue(':code', 'USD', SQLITE3_TEXT);
+    $stmt->execute();
+
+    assert_same(9.99, currency_scope_rate($db, 2, 'USD'), 'unscoped update reaches every user');
+
+    $db->close();
+});
+
+wallos_test('every currency rate update in the code base is user scoped', function () {
+    // The regression guard: any future rate write that forgets the user filter
+    // fails here rather than silently corrupting other accounts in production.
+    $paths = [
+        'endpoints/cronjobs/updateexchange.php',
+        'endpoints/currency/update_exchange.php',
+    ];
+
+    foreach ($paths as $path) {
+        $source = file_get_contents(WALLOS_ROOT . '/' . $path);
+
+        preg_match_all('/UPDATE\s+currencies\s+SET\s+rate[^"\']*/i', $source, $matches);
+        assert_true($matches[0] !== [], $path . ' still contains a rate update');
+
+        foreach ($matches[0] as $statement) {
+            assert_contains('user_id', $statement,
+                $path . ' updates rates without scoping them to a user: ' . trim($statement));
+        }
+    }
+});

--- a/tests/run.php
+++ b/tests/run.php
@@ -1,0 +1,88 @@
+<?php
+/*
+  Test runner.
+
+      php tests/run.php              run every case
+      php tests/run.php currency     run cases whose file or name matches "currency"
+
+  Exits non-zero when a case fails, so it can be used in CI.
+*/
+
+require_once __DIR__ . '/bootstrap.php';
+
+$filter = $argv[1] ?? null;
+
+if (is_dir(WALLOS_TEST_TMP)) {
+    foreach (glob(WALLOS_TEST_TMP . '/case-*.db') as $leftover) {
+        @unlink($leftover);
+    }
+} else {
+    mkdir(WALLOS_TEST_TMP, 0700, true);
+}
+
+$files = glob(__DIR__ . '/cases/*_test.php');
+sort($files);
+
+foreach ($files as $file) {
+    if ($filter !== null && stripos(basename($file), $filter) === false) {
+        // Keep the file when one of its case names matches instead.
+        $contents = file_get_contents($file);
+        if (stripos($contents, $filter) === false) {
+            continue;
+        }
+    }
+
+    require_once $file;
+}
+
+$started = microtime(true);
+$passed = 0;
+$failedTests = [];
+
+foreach ($GLOBALS['wallos_tests'] as $test) {
+    if ($filter !== null
+        && stripos($test['name'], $filter) === false
+        && stripos(basename((new ReflectionFunction($test['body']))->getFileName()), $filter) === false) {
+        continue;
+    }
+
+    $GLOBALS['wallos_test_current'] = $test['name'];
+    $before = count($GLOBALS['wallos_test_failures']);
+
+    try {
+        $test['body']();
+    } catch (Throwable $error) {
+        wallos_test_fail('threw ' . get_class($error) . ': ' . $error->getMessage()
+            . ' @ ' . basename($error->getFile()) . ':' . $error->getLine());
+    }
+
+    $newFailures = array_slice($GLOBALS['wallos_test_failures'], $before);
+
+    if ($newFailures === []) {
+        $passed++;
+        echo "\033[32m  ok\033[0m  " . $test['name'] . "\n";
+
+        continue;
+    }
+
+    $failedTests[] = $test['name'];
+    echo "\033[31mFAIL\033[0m  " . $test['name'] . "\n";
+    foreach ($newFailures as $failure) {
+        echo "        " . $failure['message'] . "\n";
+    }
+}
+
+foreach (glob(WALLOS_TEST_TMP . '/case-*.db') as $leftover) {
+    @unlink($leftover);
+}
+
+$duration = round((microtime(true) - $started) * 1000);
+$failures = count($GLOBALS['wallos_test_failures']);
+
+echo "\n";
+echo $failures === 0
+    ? sprintf("\033[32m%d tests passed\033[0m (%d assertions, %dms)\n", $passed, $GLOBALS['wallos_test_assertions'], $duration)
+    : sprintf("\033[31m%d failing assertion(s)\033[0m in %d test(s), %d passed (%dms)\n",
+        $failures, count($failedTests), $passed, $duration);
+
+exit($failures === 0 ? 0 : 1);


### PR DESCRIPTION
> Builds on #1165 and #1166. If you would prefer this standalone, I will rebase it onto main.

## The problem

Both rate refresh paths — `endpoints/cronjobs/updateexchange.php` and `endpoints/currency/update_exchange.php` — do this:

```php
foreach ($apiData['rates'] as $currencyCode => $rate) {
    ...
    $updateStmt = $db->prepare($updateQuery);   // re-prepared every iteration
    ...
    $updateResult = $updateStmt->execute();     // and autocommitted on its own

    if (!$updateResult) {
        echo "Error updating rate for currency: $currencyCode";   // then carries on
    }
}
```

Two problems follow.

**A partial refresh is silently wrong.** Rates are only comparable when they share a conversion base. If the loop stops halfway — a truncated provider response, a failing write, a fatal error — some currencies are converted against the new base and some against the old one. Totals still render, they are just incorrect, and nothing indicates it.

**The same statement is parsed once per currency.** It never changes between iterations.

## The change

- prepare the update once, before the loop, and reuse it with `reset()`
- wrap one user's rate writes and their refresh timestamp in a transaction
- roll back and report when a write fails, instead of continuing with a half-converted set

The cron job keeps its per-user granularity: one user's failure does not affect the users refreshed before or after them.

## Verification

New test cases prove the semantics rather than the implementation:

- an interrupted refresh leaves the previous rates intact
- a completed refresh commits every rate together
- five writes need one `prepare`
- a structural guard that both refresh paths open, commit and roll back a transaction, and that the prepare sits outside the loop — so a future path that autocommits per currency fails the tests

Also ran the cron job against a seeded database with six users and confirmed it leaves no transaction open when the provider is unreachable.
