### PR TITLE
Fix invalid SQL when filtering all-user subscriptions as admin

### DIFF
--- a/api/subscriptions/get_subscriptions.php
+++ b/api/subscriptions/get_subscriptions.php
@@ -217,7 +217,7 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" || $_SERVER["REQUEST_METHOD"] === "GET
     // Construction of the main SQL Query
     $params = [];
     if ($allUserSubscription == 1 && $userId == 1) {
-        $sql = "SELECT * FROM subscriptions";
+        $sql = "SELECT * FROM subscriptions WHERE 1 = 1";
     } else {
         $sql = "SELECT * FROM subscriptions WHERE user_id = :userId";
         $params[':userId'] = $userId;


### PR DESCRIPTION
## What changed
The admin-only branch of `get_subscriptions.php` (used when
`all-user-subscription=1`) built its base SQL query with no WHERE
clause. Any filter (member, category, payment, or state) then got
appended with AND, producing invalid SQL like:

    SELECT * FROM subscriptions AND inactive = :inactive

which SQLite rejects, causing prepare() to fail and a fatal error
instead of a JSON response. This PR changes the base query to
`WHERE 1 = 1` so filters can append uniformly, matching the pattern
already used in the non-admin branch.

## Why I picked this
It's a real, reproducible bug with a clear root cause and a small,
contained fix, so it felt like a solid first contribution to make
carefully rather than rushing something bigger.

## Testing
Reproduced locally by running Wallos with `php -S`, hitting
`get_subscriptions.php` with `all-user-subscription=1` and a filter
(`state=0`) as the admin user, confirming the fatal error, applying
the fix, and re-running the same request to confirm it now returns
valid filtered JSON.

Fixes #1157