### PR TITLE
fix(oidc): resolve 403 forbidden in nginx and load database connection in callback

### DIFF
--- a/includes/oidc/handle_oidc_callback.php
+++ b/includes/oidc/handle_oidc_callback.php
@@ -1,5 +1,7 @@
 <?php
 
+chdir(dirname(__DIR__, 2));
+require_once __DIR__ . '/../connect.php';
 require_once __DIR__ . '/../oidc_settings.php';
 
 function generate_username_from_email($email)

--- a/nginx.conf
+++ b/nginx.conf
@@ -51,7 +51,7 @@ http {
             return 403;
         }
 
-        location ~* ^/includes/.*\.php$ {
+        location ~* ^/includes/(?!oidc/).*\.php$ {
             deny all;
             return 403;
         }

--- a/nginx.default.conf
+++ b/nginx.default.conf
@@ -29,7 +29,7 @@ server {
         return 403;
     }
 
-    location ~* ^/includes/.*\.php$ {
+    location ~* ^/includes/(?!oidc/).*\.php$ {
         deny all;
         return 403;
     }

--- a/tests/cases/oidc_callback_test.php
+++ b/tests/cases/oidc_callback_test.php
@@ -1,0 +1,30 @@
+<?php
+/*
+  Tests for OIDC callback endpoint and Nginx routing rules.
+*/
+
+wallos_test('nginx configurations exclude oidc directory from includes deny rule', function () {
+    $configs = [
+        WALLOS_ROOT . '/nginx.conf',
+        WALLOS_ROOT . '/nginx.default.conf',
+    ];
+
+    foreach ($configs as $configPath) {
+        assert_true(file_exists($configPath), 'Nginx config exists: ' . basename($configPath));
+        $content = file_get_contents($configPath);
+
+        assert_contains('^/includes/(?!oidc/).*\.php$', $content,
+            'Nginx config ' . basename($configPath) . ' excludes oidc from deny rule');
+    }
+});
+
+wallos_test('oidc callback script establishes database connection and root working directory', function () {
+    $callbackScript = WALLOS_ROOT . '/includes/oidc/handle_oidc_callback.php';
+    assert_true(file_exists($callbackScript), 'Callback script exists');
+
+    $content = file_get_contents($callbackScript);
+    assert_contains("chdir(dirname(__DIR__, 2))", $content,
+        'Callback script switches to root working directory');
+    assert_contains("require_once __DIR__ . '/../connect.php'", $content,
+        'Callback script requires database connection');
+});


### PR DESCRIPTION
Fixes #1177

### Summary of Changes

1. **Nginx Location Configuration (`nginx.conf` & `nginx.default.conf`)**:
   - Updated `location ~* ^/includes/.*\.php$` to `location ~* ^/includes/(?!oidc/).*\.php$`.
   - This excludes `/includes/oidc/` scripts (`handle_oidc_callback.php`) from the 403 deny rule while keeping all other `/includes/*.php` files protected.

2. **OIDC Callback Handler (`includes/oidc/handle_oidc_callback.php`)**:
   - Added `chdir(dirname(__DIR__, 2));` to ensure relative database paths (`db/wallos.db`) and includes resolve correctly from the application root regardless of setup.
   - Added `require_once __DIR__ . '/../connect.php';` so `$db` is properly initialized before OIDC configuration and user lookups.

### Testing
- Verified that accessing `/includes/oidc/handle_oidc_callback.php` no longer returns 403 Forbidden and successfully processes token exchange with an OIDC provider (Authentik).
- Verified that accessing protected include files (e.g. `/includes/connect.php`) continues to return `403 Forbidden`.
