### PR TITLE
fix(auth): make the TOTP replay guard run

### DIFF
--- a/totp.php
+++ b/totp.php
@@ -55,7 +55,7 @@ if (isset($_POST['one-time-code'])) {
     $maxTotpAttempts = 5;
     $totpLockoutSeconds = 30;
 
-    $statement = $db->prepare('SELECT totp_secret, backup_codes, failed_attempts, lockout_until FROM totp WHERE user_id = :id');
+    $statement = $db->prepare('SELECT totp_secret, backup_codes, failed_attempts, lockout_until, last_totp_used FROM totp WHERE user_id = :id');
     $statement->bindValue(':id', $_SESSION['totp_user_id'], SQLITE3_INTEGER);
     $result = $statement->execute();
     $row = $result->fetchArray(SQLITE3_ASSOC);
@@ -135,16 +135,24 @@ if (isset($_POST['one-time-code'])) {
                 $statement = $db->prepare('UPDATE totp SET backup_codes = :backup_codes WHERE user_id = :id');
                 $statement->bindValue(':backup_codes', json_encode($backupCodes), SQLITE3_TEXT);
                 $statement->bindValue(':id', $_SESSION['totp_user_id'], SQLITE3_INTEGER);
-                $statement->execute();
 
-                $valid = true;
+                // A backup code is single-use, so it counts only once it has
+                // actually been struck off. Honouring one whose removal failed
+                // would leave it usable indefinitely.
+                $valid = $statement->execute() !== false;
             }
         } else {
             // Record the matched time-step so the same code cannot be reused.
             $statement = $db->prepare('UPDATE totp SET last_totp_used = :last_totp_used WHERE user_id = :id');
             $statement->bindValue(':last_totp_used', $matchedStep, SQLITE3_INTEGER);
             $statement->bindValue(':id', $_SESSION['totp_user_id'], SQLITE3_INTEGER);
-            $statement->execute();
+
+            // The login still proceeds if this cannot be stored — the code was
+            // genuine — but the replay window is then unguarded, so say so.
+            if ($statement->execute() === false) {
+                error_log('Wallos: could not record the used TOTP step for user '
+                    . (int) $_SESSION['totp_user_id'] . '; this code stays replayable until it expires');
+            }
         }
 
         // Update brute-force counters based on the result of this attempt.


### PR DESCRIPTION
`totp.php` compares a submitted code's time step against `last_totp_used`, but the SELECT feeding that comparison does not ask for the column. The value is therefore always null, `$lastUsedStep` is always 0, and since a time step is a number in the tens of millions, the reuse check on line 123 can never be true. No code has ever been rejected as reused: one observed once stays valid for the whole leeway window, about seven and a half minutes either side.

The column has existed since `migrations/000027.php`; it is simply missing from the SELECT. Adding it is the fix.

The two write results in the same block are checked while here, because both silently weaken the same guarantee:

- a backup code that could not be struck off was still accepted, which turns a single-use code into a permanent one. It now counts only if the write succeeded.
- a consumed time step that could not be stored leaves the replay window unguarded. The login still proceeds, since the code was genuine, but the gap is logged.

The practical impact is limited — replaying a code requires the account password plus a code observed within the last few minutes — so this comes as an ordinary pull request. The diff touches only `totp.php` (+12/−4) and merges cleanly into `v5_6_0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQXoSMNc3jmHHPoqRpHSVt
