### PR TITLE
fix(stats): skip subscriptions whose group is not among the seeded buckets

### DIFF
--- a/includes/stats_calculations.php
+++ b/includes/stats_calculations.php
@@ -176,11 +176,17 @@ if ($result) {
             }
             $next_payment = $subscription['next_payment'];
             $payerId = $subscription['payer_user_id'];
-            $members[$payerId]['count'] += 1;
+            if (isset($members[$payerId])) {
+                $members[$payerId]['count'] += 1;
+            }
             $categoryId = $subscription['category_id'];
-            $categories[$categoryId]['count'] += 1;
+            if (isset($categories[$categoryId])) {
+                $categories[$categoryId]['count'] += 1;
+            }
             $paymentMethodId = $subscription['payment_method_id'];
-            $paymentMethods[$paymentMethodId]['count'] += 1;
+            if (isset($paymentMethods[$paymentMethodId])) {
+                $paymentMethods[$paymentMethodId]['count'] += 1;
+            }
             $inactive = $subscription['inactive'];
             $replacementSubscriptionId = $subscription['replacement_subscription_id'];
             $originalSubscriptionPrice = getPriceConverted($price, $currency, $db, $userId);
@@ -189,11 +195,17 @@ if ($result) {
             if ($inactive == 0) {
                 if ($cycle != 5) {
                     $activeSubscriptions++;
-                    $paymentMethodsCount[$paymentMethodId]['count'] += 1;
+                    if (isset($paymentMethodsCount[$paymentMethodId])) {
+                        $paymentMethodsCount[$paymentMethodId]['count'] += 1;
+                    }
                 }
                 $totalCostPerMonth += $price;
-                $memberCost[$payerId]['cost'] += $price;
-                $categoryCost[$categoryId]['cost'] += $price;
+                if (isset($memberCost[$payerId])) {
+                    $memberCost[$payerId]['cost'] += $price;
+                }
+                if (isset($categoryCost[$categoryId])) {
+                    $categoryCost[$categoryId]['cost'] += $price;
+                }
                 if ($price > $mostExpensiveSubscription['price']) {
                     $mostExpensiveSubscription['price'] = $price;
                     $mostExpensiveSubscription['name'] = $name;


### PR DESCRIPTION
Subscriptions are tallied into buckets seeded from the categories, household and payment method tables. A subscription can name none of them: `payment_method_id` is nullable, and the payment method seeding is filtered on `enabled = 1`, so disabling a method that subscriptions still use leaves them unseeded too.

The six tally sites wrote through those ids unguarded, so a NULL id became the array key `""` and an unseeded id became a key of its own. Each raised two warnings on the stats page — one for the missing bucket, one for the missing `count` — and added a nameless bucket to the payment method breakdown.

This counts such a subscription in no bucket, which is what `stats.php` already assumes where it renders the breakdown behind `isset($paymentMethodsCount[$paymentMethodId])`.

### Reproducing

Either of these shows the warnings on Statistics before the change and none after:

1. A subscription with no payment method.
2. A subscription whose payment method is later disabled in Settings.

Closes #1182
