### PR TITLE
fix(auth): actually delete the login token on logout

### DIFF
--- a/logout.php
+++ b/logout.php
@@ -22,13 +22,26 @@ if (isset($_SESSION['from_oidc']) && $_SESSION['from_oidc'] === true) {
 }
 
 // get token from cookie to remove from DB
+//
+// $userId is not assigned anywhere in this file, so the statement bound null
+// and "user_id = null" matched no row: every logout left a usable remember-me
+// token behind, and the next request signed the browser straight back in. On a
+// shared machine that is the whole point of logging out.
+//
+// The token identifies the row on its own — it is 32 random bytes and the
+// credential itself — so scoping the delete by user adds nothing and was the
+// only reason this failed. The result is checked because a delete that could
+// not run and a token that was not there are different outcomes.
 if (isset($_SESSION['token'])) {
     $token = $_SESSION['token'];
-    $sql = "DELETE FROM login_tokens WHERE token = :token AND user_id = :userId";
+    $sql = "DELETE FROM login_tokens WHERE token = :token";
     $stmt = $db->prepare($sql);
     $stmt->bindParam(':token', $token, SQLITE3_TEXT);
-    $stmt->bindParam(':userId', $userId, SQLITE3_INTEGER);
-    $stmt->execute();
+
+    if ($stmt->execute() === false) {
+        error_log('Wallos: could not revoke the login token on logout; '
+            . 'any browser still holding the cookie stays signed in');
+    }
 }
 $_SESSION = array();
 session_destroy();


### PR DESCRIPTION
`logout.php` removes the remember-me row with `DELETE FROM login_tokens WHERE token = :token AND user_id = :userId` — and `$userId` is never assigned anywhere in that file. It includes only `includes/connect.php`, which sets `$db`, and `includes/oidc_settings.php`. The statement binds null, `user_id = null` matches no row, and the delete has never removed anything: every logout leaves the token valid in the database for the rest of its 30-day lifetime.

The browser that logged out does lose its cookie, so nothing looks wrong in normal use. What logout no longer does is revoke: any other browser still holding the same `wallos_login` cookie — a second device, or a copy taken from a shared machine — stays signed in after the user logs out, which is the situation the delete exists for.

The fix drops `user_id` from the WHERE clause instead of assigning it. The token is 32 random bytes and is itself the credential, so it identifies the row on its own; the extra condition added nothing and was the only reason the delete matched nothing. The execute result is checked while here, because a delete that could not run and a token that was not there are different outcomes.

The practical impact is limited — using the leftover token requires already holding the cookie value — so this comes as an ordinary pull request, in the same spirit as #1181. The diff touches only `logout.php` (+16/−3) and merges cleanly into `v5_6_0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Jnmyn4fw3F1fu9wuo6C87
