### PR TITLE
fix(security): validate and encode the theme cookies on the registration page

### DIFF
--- a/registration.php
+++ b/registration.php
@@ -10,6 +10,7 @@ require_once 'includes/i18n/getlang.php';
 require_once 'includes/i18n/' . $lang . '.php';
 
 require_once 'includes/version.php';
+require_once 'includes/theme_helpers.php';
 
 function validate($value)
 {
@@ -64,14 +65,14 @@ if ($userCount > 0) {
 $theme = "light";
 $updateThemeSettings = false;
 if (isset($_COOKIE['theme'])) {
-    $theme = $_COOKIE['theme'];
+    $theme = sanitize_theme_mode($_COOKIE['theme']);
 } else {
     $updateThemeSettings = true;
 }
 
 $colorTheme = "blue";
 if (isset($_COOKIE['colorTheme'])) {
-    $colorTheme = $_COOKIE['colorTheme'];
+    $colorTheme = sanitize_color_theme($_COOKIE['colorTheme']);
 }
 
 $currencies = [
@@ -348,7 +349,7 @@ if (isset($_POST['username'])) {
     <link rel="stylesheet" href="styles/barlow.css">
     <script type="text/javascript">
         window.update_theme_settings = "<?= $updateThemeSettings ?>";
-        window.colorTheme = "<?= $colorTheme ?>";
+        window.colorTheme = <?= json_encode($colorTheme, JSON_HEX_TAG | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_HEX_APOS) ?>;
     </script>
     <script type="text/javascript" src="scripts/registration.js?<?= $version ?>"></script>
     <script type="text/javascript" src="scripts/auth-theme.js?<?= $version ?>"></script>

--- a/tests/cases/theme_cookie_test.php
+++ b/tests/cases/theme_cookie_test.php
@@ -1,0 +1,91 @@
+<?php
+/*
+  The theme cookies, on their way into an inline script.
+
+  `theme` and `colorTheme` are set by the browser and read straight back out
+  into a <script> block. Written as
+
+      window.colorTheme = "<?= $colorTheme ?>";
+
+  a cookie value containing a double quote closes the string and the rest is
+  script — reflected XSS against anyone who can put a cookie on the origin.
+
+  5.5.0 fixed this by validating both cookies against a fixed list and encoding
+  what is emitted, in login.php, totp.php and includes/header.php.
+  registration.php was missed, and it is the one page of the four that renders
+  before any account exists.
+
+  This finds the pages by looking for the emission rather than from a list, so
+  a fifth one added later is covered without anybody editing this file.
+*/
+
+/**
+ * Every page that writes a theme value into an inline script.
+ *
+ * @return array<string, string> path => the emitting line
+ */
+function theme_cookie_emitters()
+{
+    $found = [];
+
+    $candidates = glob(WALLOS_ROOT . '/*.php');
+    $candidates[] = WALLOS_ROOT . '/includes/header.php';
+
+    foreach ($candidates as $file) {
+        foreach (preg_split('/\R/', file_get_contents($file)) as $line) {
+            if (preg_match('/window\.(color_?theme|theme)\s*=/i', $line) === 1) {
+                $found[str_replace(WALLOS_ROOT . '/', '', $file)] = $line;
+            }
+        }
+    }
+
+    return $found;
+}
+
+wallos_test('no page writes a theme cookie into a script unencoded', function () {
+    $emitters = theme_cookie_emitters();
+
+    // A guard that finds nothing passes every assertion after it.
+    assert_true(count($emitters) >= 4,
+        'the emitting pages were found (' . implode(', ', array_keys($emitters)) . ')');
+
+    foreach ($emitters as $path => $line) {
+        assert_true(preg_match('/window\.(color_?theme|theme)\s*=\s*"/i', $line) !== 1,
+            $path . ' does not interpolate a theme value into a quoted string: '
+            . trim($line));
+        assert_contains('json_encode(', $line,
+            $path . ' encodes the value it emits');
+    }
+});
+
+wallos_test('the value emitted was validated against a fixed list first', function () {
+    // The encoding stops the injection on its own. This stops the value
+    // reaching the stylesheet ids and the theme-colour meta tag as something
+    // that is not one of the themes, and it is what makes the encoded output
+    // predictable rather than merely safe.
+    $sanitizers = [
+        "\$_COOKIE['theme']" => 'sanitize_theme_mode',
+        "\$_COOKIE['colorTheme']" => 'sanitize_color_theme',
+        "\$_COOKIE['inUseTheme']" => 'sanitize_resolved_theme',
+    ];
+
+    $checked = 0;
+
+    foreach (array_keys(theme_cookie_emitters()) as $path) {
+        $source = file_get_contents(WALLOS_ROOT . '/' . $path);
+
+        foreach ($sanitizers as $cookie => $sanitizer) {
+            if (strpos($source, $cookie) === false) {
+                continue;
+            }
+
+            $checked++;
+            assert_contains($sanitizer . '(' . $cookie . ')', $source,
+                $path . ' validates ' . $cookie . ' before using it');
+        }
+    }
+
+    assert_true($checked >= 6,
+        'the cookie reads were found rather than the search quietly matching '
+        . 'nothing (' . $checked . ' found)');
+});


### PR DESCRIPTION
5.5.0 fixed reflected XSS through the `theme` and `colorTheme` cookies by
validating both against a fixed list and encoding what is written into the
inline script — in `login.php`, `totp.php` and `includes/header.php`.

`registration.php` was not covered and still writes the cookie straight into
the script:

```php
window.colorTheme = "<?= $colorTheme ?>";
```

A cookie value containing a double quote closes the string and the rest is
script.

**To see it:** set `document.cookie = 'colorTheme=";alert(1);//'` on the origin
and load `registration.php`.

This is the same one-line change as the three pages already fixed, using the
`sanitize_*` helpers that release added, so there is nothing new to review.
It seemed worth having because `registration.php` renders before any account
exists — it is the one page of the four reachable with no session at all.

`$theme` is validated here too. It only reaches comparisons on this page, so it
was not injectable, but leaving one of the two cookies unchecked in a file
whose point is now that they are checked invites the next edit to reintroduce
it.

### The test

`tests/cases/theme_cookie_test.php` runs in the existing harness
(`php tests/run.php`). It finds the emitting pages by searching for the
emission rather than from a hardcoded list, so a fifth page added later is
covered without editing the test, and it counts what it found so it cannot pass
by matching nothing.

Checked by putting the old `registration.php` back: it fails and prints the
offending line.
