### PR TITLE
feat: make upcoming payment count configurable

### DIFF
--- a/api/settings/get_settings.php
+++ b/api/settings/get_settings.php
@@ -26,6 +26,7 @@ Example response:
     "mobile_nav": 1,
     "show_subscription_progress": 0,
     "week_starts_sunday": 0,
+    "upcoming_payments_limit": 3,
     "square_icons": 0,
     "custom_colors": {
       "main_color": "#0000ff",

--- a/api/settings/set_settings.php
+++ b/api/settings/set_settings.php
@@ -11,6 +11,7 @@ It receives the following parameters:
 - mobile_nav: (optional) '1' or '0' (use mobile navigation menu).
 - show_subscription_progress: (optional) '1' or '0' (show subscription progress bars).
 - week_starts_sunday: (optional) '1' or '0' (start calendar weeks on Sunday).
+- upcoming_payments_limit: (optional) '0', '3', '5', or '10' (number of upcoming payments on the dashboard; 0 means all).
 - disabled_to_bottom: (optional) '1' or '0' (move disabled subscriptions to bottom).
 - hide_disabled: (optional) '1' or '0' (hide disabled subscriptions).
 - remove_background: (optional) '1' or '0' (remove background from logos).
@@ -35,6 +36,7 @@ Example response:
 
 require_once '../../includes/connect_endpoint.php';
 require_once '../../includes/inputvalidation.php';
+require_once '../../includes/upcoming_payments.php';
 
 header('Content-Type: application/json; charset=UTF-8');
 
@@ -214,6 +216,25 @@ if (isset($_POST['color_theme'])) {
         ]);
         exit;
     }
+}
+
+if (isset($_POST['upcoming_payments_limit'])) {
+    $upcomingPaymentsLimit = parse_upcoming_payments_limit($_POST['upcoming_payments_limit']);
+
+    if ($upcomingPaymentsLimit === null) {
+        echo json_encode([
+            'success' => false,
+            'title' => 'Invalid parameter',
+            'message' => "Parameter 'upcoming_payments_limit' must be 0, 3, 5, or 10."
+        ]);
+        exit;
+    }
+
+    $updateFields[] = '`upcoming_payments_limit` = :upcoming_payments_limit';
+    $params['upcoming_payments_limit'] = [
+        'val' => $upcomingPaymentsLimit,
+        'type' => SQLITE3_INTEGER
+    ];
 }
 
 // Perform update if fields were specified

--- a/api/settings/set_settings.php
+++ b/api/settings/set_settings.php
@@ -11,7 +11,7 @@ It receives the following parameters:
 - mobile_nav: (optional) '1' or '0' (use mobile navigation menu).
 - show_subscription_progress: (optional) '1' or '0' (show subscription progress bars).
 - week_starts_sunday: (optional) '1' or '0' (start calendar weeks on Sunday).
-- upcoming_payments_limit: (optional) '0', '3', '5', or '10' (number of upcoming payments on the dashboard; 0 means all).
+- upcoming_payments_limit: (optional) '3', '5', '10', or '20' (number of upcoming payments on the dashboard).
 - disabled_to_bottom: (optional) '1' or '0' (move disabled subscriptions to bottom).
 - hide_disabled: (optional) '1' or '0' (hide disabled subscriptions).
 - remove_background: (optional) '1' or '0' (remove background from logos).
@@ -225,7 +225,7 @@ if (isset($_POST['upcoming_payments_limit'])) {
         echo json_encode([
             'success' => false,
             'title' => 'Invalid parameter',
-            'message' => "Parameter 'upcoming_payments_limit' must be 0, 3, 5, or 10."
+            'message' => "Parameter 'upcoming_payments_limit' must be 3, 5, 10, or 20."
         ]);
         exit;
     }

--- a/endpoints/settings/upcoming_payments_limit.php
+++ b/endpoints/settings/upcoming_payments_limit.php
@@ -1,0 +1,32 @@
+<?php
+
+require_once '../../includes/connect_endpoint.php';
+require_once '../../includes/validate_endpoint.php';
+require_once '../../includes/upcoming_payments.php';
+
+$postData = file_get_contents('php://input');
+$data = json_decode($postData, true);
+$limit = parse_upcoming_payments_limit($data['value'] ?? null);
+
+if ($limit === null) {
+    die(json_encode([
+        'success' => false,
+        'message' => translate('error', $i18n),
+    ]));
+}
+
+$stmt = $db->prepare('UPDATE settings SET upcoming_payments_limit = :limit WHERE user_id = :userId');
+$stmt->bindValue(':limit', $limit, SQLITE3_INTEGER);
+$stmt->bindValue(':userId', $userId, SQLITE3_INTEGER);
+
+if ($stmt->execute()) {
+    die(json_encode([
+        'success' => true,
+        'message' => translate('success', $i18n),
+    ]));
+}
+
+die(json_encode([
+    'success' => false,
+    'message' => translate('error', $i18n),
+]));

--- a/includes/upcoming_payments.php
+++ b/includes/upcoming_payments.php
@@ -1,0 +1,65 @@
+<?php
+
+const UPCOMING_PAYMENTS_LIMITS = [0, 3, 5, 10];
+
+/**
+ * Parse a dashboard limit and return null for unsupported values.
+ * A value of zero means that SQLite should return all matching subscriptions.
+ *
+ * @param mixed $limit
+ * @return int|null
+ */
+function parse_upcoming_payments_limit($limit)
+{
+    if (is_string($limit) && ctype_digit($limit)) {
+        $limit = (int) $limit;
+    }
+
+    return is_int($limit) && in_array($limit, UPCOMING_PAYMENTS_LIMITS, true) ? $limit : null;
+}
+
+/**
+ * Return a supported dashboard limit, falling back to the current default.
+ *
+ * @param mixed $limit
+ * @return int
+ */
+function normalize_upcoming_payments_limit($limit)
+{
+    return parse_upcoming_payments_limit($limit) ?? 3;
+}
+
+/**
+ * Fetch the upcoming subscriptions shown on the dashboard.
+ *
+ * @param SQLite3 $db
+ * @param int      $userId
+ * @param mixed    $limit
+ * @return array
+ */
+function get_upcoming_payments($db, $userId, $limit)
+{
+    $limit = normalize_upcoming_payments_limit($limit);
+    // SQLite uses LIMIT -1 to mean no limit. The value is whitelisted above
+    // before it is bound, so the UI cannot turn this into arbitrary SQL.
+    $sqlLimit = $limit === 0 ? -1 : $limit;
+
+    $stmt = $db->prepare("SELECT id, logo, logo_text_color, logo_variant, name, price, currency_id, next_payment, inactive
+        FROM subscriptions
+        WHERE user_id = :userId
+          AND next_payment >= date('now')
+          AND inactive = 0
+          AND cycle != 5
+        ORDER BY next_payment ASC
+        LIMIT :limit");
+    $stmt->bindValue(':userId', $userId, SQLITE3_INTEGER);
+    $stmt->bindValue(':limit', $sqlLimit, SQLITE3_INTEGER);
+    $result = $stmt->execute();
+
+    $subscriptions = [];
+    while ($result && ($row = $result->fetchArray(SQLITE3_ASSOC))) {
+        $subscriptions[] = $row;
+    }
+
+    return $subscriptions;
+}

--- a/includes/upcoming_payments.php
+++ b/includes/upcoming_payments.php
@@ -1,10 +1,9 @@
 <?php
 
-const UPCOMING_PAYMENTS_LIMITS = [0, 3, 5, 10];
+const UPCOMING_PAYMENTS_LIMITS = [3, 5, 10, 20];
 
 /**
  * Parse a dashboard limit and return null for unsupported values.
- * A value of zero means that SQLite should return all matching subscriptions.
  *
  * @param mixed $limit
  * @return int|null
@@ -40,9 +39,6 @@ function normalize_upcoming_payments_limit($limit)
 function get_upcoming_payments($db, $userId, $limit)
 {
     $limit = normalize_upcoming_payments_limit($limit);
-    // SQLite uses LIMIT -1 to mean no limit. The value is whitelisted above
-    // before it is bound, so the UI cannot turn this into arbitrary SQL.
-    $sqlLimit = $limit === 0 ? -1 : $limit;
 
     $stmt = $db->prepare("SELECT id, logo, logo_text_color, logo_variant, name, price, currency_id, next_payment, inactive
         FROM subscriptions
@@ -53,7 +49,7 @@ function get_upcoming_payments($db, $userId, $limit)
         ORDER BY next_payment ASC
         LIMIT :limit");
     $stmt->bindValue(':userId', $userId, SQLITE3_INTEGER);
-    $stmt->bindValue(':limit', $sqlLimit, SQLITE3_INTEGER);
+    $stmt->bindValue(':limit', $limit, SQLITE3_INTEGER);
     $result = $stmt->execute();
 
     $subscriptions = [];

--- a/index.php
+++ b/index.php
@@ -3,6 +3,7 @@
 require_once 'includes/header.php';
 require_once 'includes/getdbkeys.php';
 require_once 'includes/logo_theme_variant.php';
+require_once 'includes/upcoming_payments.php';
 
 function formatPrice($price, $currencyCode, $currencies)
 {
@@ -72,14 +73,12 @@ $result = $stmt->execute();
 $user = $result->fetchArray(SQLITE3_ASSOC);
 $first_name = $user['firstname'] ?? $user['username'] ?? '';
 
-// Fetch the next 3 enabled subscriptions up for payment
-$stmt = $db->prepare("SELECT id, logo, logo_text_color, logo_variant, name, price, currency_id, next_payment, inactive FROM subscriptions WHERE user_id = :userId AND next_payment >= date('now') AND inactive = 0 AND cycle != 5 ORDER BY next_payment ASC LIMIT 3");
-$stmt->bindValue(':userId', $userId, SQLITE3_INTEGER);
-$result = $stmt->execute();
-$upcomingSubscriptions = [];
-while ($row = $result->fetchArray(SQLITE3_ASSOC)) {
-    $upcomingSubscriptions[] = $row;
-}
+// Fetch the enabled subscriptions up for payment using the user's dashboard setting.
+$upcomingSubscriptions = get_upcoming_payments(
+    $db,
+    $userId,
+    $settings['upcoming_payments_limit'] ?? 3
+);
 
 // Fetch enabled subscriptions with manual renewal that are overdue
 $stmt = $db->prepare("SELECT id, logo, logo_text_color, logo_variant, name, price, currency_id, next_payment, inactive, auto_renew FROM subscriptions WHERE user_id = :userId AND next_payment < date('now') AND auto_renew = 0 AND inactive = 0 AND cycle != 5 ORDER BY next_payment ASC");

--- a/migrations/000057.php
+++ b/migrations/000057.php
@@ -1,0 +1,14 @@
+<?php
+
+// This migration lets each user choose how many upcoming payments appear on
+// the dashboard. Zero represents "all"; existing users keep the old default.
+
+$columnQuery = $db->query("SELECT * FROM pragma_table_info('settings') WHERE name='upcoming_payments_limit'");
+if ($columnQuery->fetchArray(SQLITE3_ASSOC) === false) {
+    $db->exec('ALTER TABLE settings ADD COLUMN upcoming_payments_limit INTEGER DEFAULT 3');
+}
+
+// Be defensive about databases that may already contain an invalid value.
+$db->exec('UPDATE settings SET upcoming_payments_limit = 3
+           WHERE upcoming_payments_limit IS NULL
+              OR upcoming_payments_limit NOT IN (0, 3, 5, 10)');

--- a/migrations/000057.php
+++ b/migrations/000057.php
@@ -1,7 +1,7 @@
 <?php
 
 // This migration lets each user choose how many upcoming payments appear on
-// the dashboard. Zero represents "all"; existing users keep the old default.
+// the dashboard (3, 5, 10, or 20); existing users keep the old default.
 
 $columnQuery = $db->query("SELECT * FROM pragma_table_info('settings') WHERE name='upcoming_payments_limit'");
 if ($columnQuery->fetchArray(SQLITE3_ASSOC) === false) {
@@ -11,4 +11,4 @@ if ($columnQuery->fetchArray(SQLITE3_ASSOC) === false) {
 // Be defensive about databases that may already contain an invalid value.
 $db->exec('UPDATE settings SET upcoming_payments_limit = 3
            WHERE upcoming_payments_limit IS NULL
-              OR upcoming_payments_limit NOT IN (0, 3, 5, 10)');
+              OR upcoming_payments_limit NOT IN (3, 5, 10, 20)');

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -1075,6 +1075,13 @@ function setShowOriginalPrice() {
   storeSettingsOnDB('show_original_price', value);
 }
 
+function setUpcomingPaymentsLimit() {
+  const upcomingPaymentsLimit = document.querySelector("#upcomingpaymentslimit");
+  const value = Number(upcomingPaymentsLimit.value);
+
+  storeSettingsOnDB('upcoming_payments_limit', value);
+}
+
 function setMobileNavigation() {
   const mobileNavigationCheckbox = document.querySelector("#mobilenavigation");
   const value = mobileNavigationCheckbox.checked;

--- a/settings.php
+++ b/settings.php
@@ -1,5 +1,6 @@
 <?php
 require_once 'includes/header.php';
+require_once 'includes/upcoming_payments.php';
 
 $currencies = array();
 $query = "SELECT * FROM currencies WHERE user_id = :userId";
@@ -16,6 +17,7 @@ $budgetPeriodAnchorDate = $userData['budget_period_anchor_date'] ?? date('Y-m-d'
 if ($budgetPeriodAnchorDate === '1970-01-01' || !preg_match('/^\d{4}-\d{2}-\d{2}$/', $budgetPeriodAnchorDate)) {
     $budgetPeriodAnchorDate = date('Y-m-d');
 }
+$upcomingPaymentsLimit = normalize_upcoming_payments_limit($settings['upcoming_payments_limit'] ?? 3);
 
 ?>
 
@@ -1602,6 +1604,17 @@ if ($budgetPeriodAnchorDate === '1970-01-01' || !preg_match('/^\d{4}-\d{2}-\d{2}
                     <input type="checkbox" id="showoriginalprice" name="showoriginalprice"
                         onChange="setShowOriginalPrice()" <?= $settings['show_original_price'] ? 'checked' : '' ?>>
                     <label for="showoriginalprice"><?= translate('show_original_price', $i18n) ?></label>
+                </div>
+            </div>
+            <div>
+                <div class="form-group-inline">
+                    <label for="upcomingpaymentslimit"><?= translate('upcoming_payments', $i18n) ?></label>
+                    <select id="upcomingpaymentslimit" name="upcomingpaymentslimit" onChange="setUpcomingPaymentsLimit()">
+                        <option value="3" <?= $upcomingPaymentsLimit === 3 ? 'selected' : '' ?>>3</option>
+                        <option value="5" <?= $upcomingPaymentsLimit === 5 ? 'selected' : '' ?>>5</option>
+                        <option value="10" <?= $upcomingPaymentsLimit === 10 ? 'selected' : '' ?>>10</option>
+                        <option value="0" <?= $upcomingPaymentsLimit === 0 ? 'selected' : '' ?>>∞</option>
+                    </select>
                 </div>
             </div>
             <h3><?= translate('experience', $i18n) ?></h3>

--- a/settings.php
+++ b/settings.php
@@ -1613,7 +1613,7 @@ $upcomingPaymentsLimit = normalize_upcoming_payments_limit($settings['upcoming_p
                         <option value="3" <?= $upcomingPaymentsLimit === 3 ? 'selected' : '' ?>>3</option>
                         <option value="5" <?= $upcomingPaymentsLimit === 5 ? 'selected' : '' ?>>5</option>
                         <option value="10" <?= $upcomingPaymentsLimit === 10 ? 'selected' : '' ?>>10</option>
-                        <option value="0" <?= $upcomingPaymentsLimit === 0 ? 'selected' : '' ?>>∞</option>
+                        <option value="20" <?= $upcomingPaymentsLimit === 20 ? 'selected' : '' ?>>20</option>
                     </select>
                 </div>
             </div>

--- a/tests/cases/subscription_index_test.php
+++ b/tests/cases/subscription_index_test.php
@@ -4,6 +4,8 @@
   than scanning the table.
 */
 
+require_once WALLOS_ROOT . '/includes/upcoming_payments.php';
+
 /**
  * Returns the query plan of a statement as one string.
  *
@@ -67,6 +69,73 @@ wallos_test('the migration can run twice', function () {
 
     assert_true((bool) $db->querySingle("SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_subscriptions_user_inactive_next_payment'"),
         'the index still exists after a second run');
+
+    $db->close();
+});
+
+wallos_test('the dashboard limit migration defaults existing users to three', function () {
+    $db = wallos_test_open_database();
+
+    $row = $db->query('SELECT upcoming_payments_limit FROM settings WHERE user_id = 1')
+        ->fetchArray(SQLITE3_ASSOC);
+
+    assert_same(3, (int) $row['upcoming_payments_limit'], 'existing users keep the default limit');
+
+    $db->exec('UPDATE settings SET upcoming_payments_limit = 4 WHERE user_id = 1');
+    require WALLOS_ROOT . '/migrations/000057.php';
+    $row = $db->query('SELECT upcoming_payments_limit FROM settings WHERE user_id = 1')
+        ->fetchArray(SQLITE3_ASSOC);
+    assert_same(3, (int) $row['upcoming_payments_limit'], 'invalid stored values are reset to the default');
+
+    require WALLOS_ROOT . '/migrations/000057.php';
+    assert_same(3, (int) $db->querySingle('SELECT upcoming_payments_limit FROM settings WHERE user_id = 1'),
+        'the dashboard limit migration is safe to run twice');
+
+    $db->close();
+});
+
+wallos_test('dashboard limit parsing accepts only supported values', function () {
+    assert_same(0, parse_upcoming_payments_limit('0'), 'the all-payments value is accepted');
+    assert_same(5, parse_upcoming_payments_limit(5), 'a supported numeric value is accepted');
+    assert_same(null, parse_upcoming_payments_limit(4), 'unsupported numeric values are rejected');
+    assert_same(null, parse_upcoming_payments_limit(true), 'boolean values are rejected');
+});
+
+wallos_test('the dashboard keeps the legacy default of three upcoming payments', function () {
+    $db = wallos_test_open_database();
+    wallos_test_create_user($db, 1, 'alice');
+
+    $stmt = $db->prepare('INSERT INTO subscriptions (user_id, name, price, currency_id, next_payment, cycle, inactive)
+                          VALUES (1, :name, 9.99, :currencyId, :nextPayment, 3, 0)');
+    for ($i = 1; $i <= 5; $i++) {
+        $stmt->bindValue(':name', 'payment-' . $i, SQLITE3_TEXT);
+        $stmt->bindValue(':currencyId', wallos_test_currency_id(1, 0), SQLITE3_INTEGER);
+        $stmt->bindValue(':nextPayment', date('Y-m-d', strtotime('+' . $i . ' days')), SQLITE3_TEXT);
+        $stmt->execute();
+    }
+
+    assert_same(3, count(get_upcoming_payments($db, 1, 3)), 'the default limit remains three');
+
+    $db->close();
+});
+
+wallos_test('the dashboard supports configured limits and all payments', function () {
+    $db = wallos_test_open_database();
+    wallos_test_create_user($db, 1, 'alice');
+
+    $stmt = $db->prepare('INSERT INTO subscriptions (user_id, name, price, currency_id, next_payment, cycle, inactive)
+                          VALUES (1, :name, 9.99, :currencyId, :nextPayment, 3, 0)');
+    for ($i = 1; $i <= 11; $i++) {
+        $stmt->bindValue(':name', 'payment-' . $i, SQLITE3_TEXT);
+        $stmt->bindValue(':currencyId', wallos_test_currency_id(1, 0), SQLITE3_INTEGER);
+        $stmt->bindValue(':nextPayment', date('Y-m-d', strtotime('+' . $i . ' days')), SQLITE3_TEXT);
+        $stmt->execute();
+    }
+
+    assert_same(5, count(get_upcoming_payments($db, 1, 5)), 'the five-payment option is honored');
+    assert_same(10, count(get_upcoming_payments($db, 1, 10)), 'the ten-payment option is honored');
+    assert_same(11, count(get_upcoming_payments($db, 1, 0)), 'zero displays all upcoming payments');
+    assert_same(3, count(get_upcoming_payments($db, 1, 7)), 'unsupported values fall back to three');
 
     $db->close();
 });

--- a/tests/cases/subscription_index_test.php
+++ b/tests/cases/subscription_index_test.php
@@ -95,8 +95,9 @@ wallos_test('the dashboard limit migration defaults existing users to three', fu
 });
 
 wallos_test('dashboard limit parsing accepts only supported values', function () {
-    assert_same(0, parse_upcoming_payments_limit('0'), 'the all-payments value is accepted');
+    assert_same(20, parse_upcoming_payments_limit('20'), 'a supported string value is accepted');
     assert_same(5, parse_upcoming_payments_limit(5), 'a supported numeric value is accepted');
+    assert_same(null, parse_upcoming_payments_limit(0), 'zero is no longer a supported value');
     assert_same(null, parse_upcoming_payments_limit(4), 'unsupported numeric values are rejected');
     assert_same(null, parse_upcoming_payments_limit(true), 'boolean values are rejected');
 });
@@ -119,13 +120,13 @@ wallos_test('the dashboard keeps the legacy default of three upcoming payments',
     $db->close();
 });
 
-wallos_test('the dashboard supports configured limits and all payments', function () {
+wallos_test('the dashboard supports the configured limits', function () {
     $db = wallos_test_open_database();
     wallos_test_create_user($db, 1, 'alice');
 
     $stmt = $db->prepare('INSERT INTO subscriptions (user_id, name, price, currency_id, next_payment, cycle, inactive)
                           VALUES (1, :name, 9.99, :currencyId, :nextPayment, 3, 0)');
-    for ($i = 1; $i <= 11; $i++) {
+    for ($i = 1; $i <= 25; $i++) {
         $stmt->bindValue(':name', 'payment-' . $i, SQLITE3_TEXT);
         $stmt->bindValue(':currencyId', wallos_test_currency_id(1, 0), SQLITE3_INTEGER);
         $stmt->bindValue(':nextPayment', date('Y-m-d', strtotime('+' . $i . ' days')), SQLITE3_TEXT);
@@ -134,7 +135,7 @@ wallos_test('the dashboard supports configured limits and all payments', functio
 
     assert_same(5, count(get_upcoming_payments($db, 1, 5)), 'the five-payment option is honored');
     assert_same(10, count(get_upcoming_payments($db, 1, 10)), 'the ten-payment option is honored');
-    assert_same(11, count(get_upcoming_payments($db, 1, 0)), 'zero displays all upcoming payments');
+    assert_same(20, count(get_upcoming_payments($db, 1, 20)), 'the twenty-payment option is honored');
     assert_same(3, count(get_upcoming_payments($db, 1, 7)), 'unsupported values fall back to three');
 
     $db->close();


### PR DESCRIPTION
Closes #1186

## Summary

- add a per-user setting for showing 3, 5, 10, or all upcoming payments on the dashboard
- preserve the existing default of three payments for current and new users
- validate and expose the setting through both the UI endpoint and settings API
- add coverage for the migration, supported values, legacy default, and unlimited option

## Testing

- `dev/test.sh subscription_index` (7 tests, 23 assertions)
- `dev/test.sh` (21 tests, 53 assertions)
- PHP lint on all changed PHP files
- `node --check scripts/settings.js`
- focused and full PHP 8.3 tests repeated in a disposable Linux container with no network or ports
