### PR TITLE
fix: delete everything that belonged to an account, not nineteen of thirty-one

### DIFF
--- a/endpoints/admin/deleteuser.php
+++ b/endpoints/admin/deleteuser.php
@@ -109,6 +109,72 @@ if ($userId == 1) {
     $stmt->bindValue(':id', $userId, SQLITE3_INTEGER);
     $result = $stmt->execute();
 
+    // The twelve tables this used to leave behind. Two of them hold
+    // credentials — a remember-me token and a password reset token — and
+    // the user table has no AUTOINCREMENT, so SQLite hands a deleted id
+    // straight back to the next account created. That account inherited
+    // them.
+
+    // Delete login tokens
+    $stmt = $db->prepare('DELETE FROM login_tokens WHERE user_id = :id');
+    $stmt->bindValue(':id', $userId, SQLITE3_INTEGER);
+    $result = $stmt->execute();
+
+    // Delete password reset tokens
+    $stmt = $db->prepare('DELETE FROM password_resets WHERE user_id = :id');
+    $stmt->bindValue(':id', $userId, SQLITE3_INTEGER);
+    $result = $stmt->execute();
+
+    // Delete custom CSS
+    $stmt = $db->prepare('DELETE FROM custom_css_style WHERE user_id = :id');
+    $stmt->bindValue(':id', $userId, SQLITE3_INTEGER);
+    $result = $stmt->execute();
+
+    // Delete uploaded avatars
+    $stmt = $db->prepare('DELETE FROM uploaded_avatars WHERE user_id = :id');
+    $stmt->bindValue(':id', $userId, SQLITE3_INTEGER);
+    $result = $stmt->execute();
+
+    // Delete AI settings
+    $stmt = $db->prepare('DELETE FROM ai_settings WHERE user_id = :id');
+    $stmt->bindValue(':id', $userId, SQLITE3_INTEGER);
+    $result = $stmt->execute();
+
+    // Delete AI recommendations
+    $stmt = $db->prepare('DELETE FROM ai_recommendations WHERE user_id = :id');
+    $stmt->bindValue(':id', $userId, SQLITE3_INTEGER);
+    $result = $stmt->execute();
+
+    // Delete Google search settings
+    $stmt = $db->prepare('DELETE FROM google_search WHERE user_id = :id');
+    $stmt->bindValue(':id', $userId, SQLITE3_INTEGER);
+    $result = $stmt->execute();
+
+    // Delete ntfy notifications
+    $stmt = $db->prepare('DELETE FROM ntfy_notifications WHERE user_id = :id');
+    $stmt->bindValue(':id', $userId, SQLITE3_INTEGER);
+    $result = $stmt->execute();
+
+    // Delete Mattermost notifications
+    $stmt = $db->prepare('DELETE FROM mattermost_notifications WHERE user_id = :id');
+    $stmt->bindValue(':id', $userId, SQLITE3_INTEGER);
+    $result = $stmt->execute();
+
+    // Delete Discord notifications
+    $stmt = $db->prepare('DELETE FROM discord_notifications WHERE user_id = :id');
+    $stmt->bindValue(':id', $userId, SQLITE3_INTEGER);
+    $result = $stmt->execute();
+
+    // Delete PushPlus notifications
+    $stmt = $db->prepare('DELETE FROM pushplus_notifications WHERE user_id = :id');
+    $stmt->bindValue(':id', $userId, SQLITE3_INTEGER);
+    $result = $stmt->execute();
+
+    // Delete ServerChan notifications
+    $stmt = $db->prepare('DELETE FROM serverchan_notifications WHERE user_id = :id');
+    $stmt->bindValue(':id', $userId, SQLITE3_INTEGER);
+    $result = $stmt->execute();
+
     die(json_encode([
         "success" => true,
         "message" => translate('success', $i18n)

--- a/endpoints/settings/deleteaccount.php
+++ b/endpoints/settings/deleteaccount.php
@@ -109,6 +109,72 @@ if ($userIdToDelete == 1 || $userIdToDelete != $userId) {
     $stmt->bindValue(':id', $userIdToDelete, SQLITE3_INTEGER);
     $result = $stmt->execute();
 
+    // The twelve tables this used to leave behind. Two of them hold
+    // credentials — a remember-me token and a password reset token — and
+    // the user table has no AUTOINCREMENT, so SQLite hands a deleted id
+    // straight back to the next account created. That account inherited
+    // them.
+
+    // Delete login tokens
+    $stmt = $db->prepare('DELETE FROM login_tokens WHERE user_id = :id');
+    $stmt->bindValue(':id', $userIdToDelete, SQLITE3_INTEGER);
+    $result = $stmt->execute();
+
+    // Delete password reset tokens
+    $stmt = $db->prepare('DELETE FROM password_resets WHERE user_id = :id');
+    $stmt->bindValue(':id', $userIdToDelete, SQLITE3_INTEGER);
+    $result = $stmt->execute();
+
+    // Delete custom CSS
+    $stmt = $db->prepare('DELETE FROM custom_css_style WHERE user_id = :id');
+    $stmt->bindValue(':id', $userIdToDelete, SQLITE3_INTEGER);
+    $result = $stmt->execute();
+
+    // Delete uploaded avatars
+    $stmt = $db->prepare('DELETE FROM uploaded_avatars WHERE user_id = :id');
+    $stmt->bindValue(':id', $userIdToDelete, SQLITE3_INTEGER);
+    $result = $stmt->execute();
+
+    // Delete AI settings
+    $stmt = $db->prepare('DELETE FROM ai_settings WHERE user_id = :id');
+    $stmt->bindValue(':id', $userIdToDelete, SQLITE3_INTEGER);
+    $result = $stmt->execute();
+
+    // Delete AI recommendations
+    $stmt = $db->prepare('DELETE FROM ai_recommendations WHERE user_id = :id');
+    $stmt->bindValue(':id', $userIdToDelete, SQLITE3_INTEGER);
+    $result = $stmt->execute();
+
+    // Delete Google search settings
+    $stmt = $db->prepare('DELETE FROM google_search WHERE user_id = :id');
+    $stmt->bindValue(':id', $userIdToDelete, SQLITE3_INTEGER);
+    $result = $stmt->execute();
+
+    // Delete ntfy notifications
+    $stmt = $db->prepare('DELETE FROM ntfy_notifications WHERE user_id = :id');
+    $stmt->bindValue(':id', $userIdToDelete, SQLITE3_INTEGER);
+    $result = $stmt->execute();
+
+    // Delete Mattermost notifications
+    $stmt = $db->prepare('DELETE FROM mattermost_notifications WHERE user_id = :id');
+    $stmt->bindValue(':id', $userIdToDelete, SQLITE3_INTEGER);
+    $result = $stmt->execute();
+
+    // Delete Discord notifications
+    $stmt = $db->prepare('DELETE FROM discord_notifications WHERE user_id = :id');
+    $stmt->bindValue(':id', $userIdToDelete, SQLITE3_INTEGER);
+    $result = $stmt->execute();
+
+    // Delete PushPlus notifications
+    $stmt = $db->prepare('DELETE FROM pushplus_notifications WHERE user_id = :id');
+    $stmt->bindValue(':id', $userIdToDelete, SQLITE3_INTEGER);
+    $result = $stmt->execute();
+
+    // Delete ServerChan notifications
+    $stmt = $db->prepare('DELETE FROM serverchan_notifications WHERE user_id = :id');
+    $stmt->bindValue(':id', $userIdToDelete, SQLITE3_INTEGER);
+    $result = $stmt->execute();
+
     die(json_encode([
         "success" => true,
         "message" => translate('success', $i18n)

--- a/tests/cases/account_deletion_test.php
+++ b/tests/cases/account_deletion_test.php
@@ -1,0 +1,110 @@
+<?php
+/*
+  Deleting an account removes what belongs to it.
+
+  Both deletion paths — the self-service one and the administrator one — named
+  their tables by hand, and the hand-written list had fallen twelve tables
+  behind the schema. Two of the twelve hold credentials: `login_tokens` and
+  `password_resets`.
+
+  That is not only untidiness. The `user` table is declared
+  `id INTEGER PRIMARY KEY` with no AUTOINCREMENT, so SQLite hands a deleted id
+  straight back to the next account created — and that account inherited the
+  leftovers, including a remember-me token that still worked.
+
+  The list below is read from the schema rather than written down again, so a
+  table added by a future migration is covered by this test on the day it
+  appears, without anybody remembering to come back here.
+*/
+
+/**
+ * Every table the schema gives a user_id column.
+ *
+ * @param SQLite3 $db
+ * @return string[]
+ */
+function account_deletion_user_tables($db)
+{
+    $tables = [];
+    $result = $db->query("SELECT name FROM sqlite_master WHERE type = 'table'
+                          AND name NOT LIKE 'sqlite_%' ORDER BY name");
+
+    while ($row = $result->fetchArray(SQLITE3_ASSOC)) {
+        $columns = $db->query('PRAGMA table_info("' . $row['name'] . '")');
+
+        while ($column = $columns->fetchArray(SQLITE3_ASSOC)) {
+            if ($column['name'] === 'user_id') {
+                $tables[] = $row['name'];
+                break;
+            }
+        }
+    }
+
+    return $tables;
+}
+
+/**
+ * The tables a deletion path names.
+ *
+ * @param string $path
+ * @return string[]
+ */
+function account_deletion_tables_named($path)
+{
+    $source = file_get_contents(WALLOS_ROOT . '/' . $path);
+    preg_match_all('/DELETE FROM\s+["\']?(\w+)["\']?/i', $source, $matches);
+
+    return array_values(array_unique($matches[1]));
+}
+
+wallos_test('both deletion paths cover every table that belongs to a user', function () {
+    $db = wallos_test_open_database();
+    $userTables = account_deletion_user_tables($db);
+    $db->close();
+
+    // A guard that finds nothing passes every assertion after it.
+    assert_true(count($userTables) >= 25,
+        'the schema was read (' . count($userTables) . ' tables carry a user_id)');
+
+    foreach ([
+        'endpoints/settings/deleteaccount.php',
+        'endpoints/admin/deleteuser.php',
+    ] as $path) {
+        $named = account_deletion_tables_named($path);
+        $missing = array_values(array_diff($userTables, $named));
+
+        assert_same([], $missing,
+            $path . ' leaves nothing behind (missing: ' . implode(', ', $missing) . ')');
+    }
+});
+
+wallos_test('the two paths agree with each other', function () {
+    // They were two hand-maintained copies of one list, which is how they
+    // drifted together and would drift apart. Whichever one a future table is
+    // added to, this fails until it is added to both.
+    $self = account_deletion_tables_named('endpoints/settings/deleteaccount.php');
+    $admin = account_deletion_tables_named('endpoints/admin/deleteuser.php');
+
+    sort($self);
+    sort($admin);
+
+    assert_same($self, $admin,
+        'the self-service and administrator paths delete the same tables');
+});
+
+wallos_test('the credentials of a deleted account do not survive it', function () {
+    // Named separately from the schema sweep above, because these two are the
+    // reason the sweep is worth having: an id handed back out carries them to
+    // whoever gets it next.
+    foreach ([
+        'endpoints/settings/deleteaccount.php',
+        'endpoints/admin/deleteuser.php',
+    ] as $path) {
+        $named = account_deletion_tables_named($path);
+
+        assert_true(in_array('login_tokens', $named, true),
+            $path . ' removes the remember-me tokens');
+        assert_true(in_array('password_resets', $named, true),
+            $path . ' removes the outstanding password reset tokens');
+    }
+});


### PR DESCRIPTION
Both deletion paths — the self-service one and the administrator one — name
their tables by hand, and the hand-written list had fallen twelve tables
behind the schema. The database has 38 tables, 31 of them carry a user_id, and
both paths removed rows from 19.

Left behind: login_tokens, password_resets, custom_css_style, uploaded_avatars,
ai_settings, ai_recommendations, google_search, and the ntfy, mattermost,
discord, pushplus and serverchan notification settings.

The first two are the reason this is more than untidiness. The user table is
declared `id INTEGER PRIMARY KEY` with no AUTOINCREMENT, so SQLite hands a
deleted id straight back to the next account created — and that account
inherits the leftovers, including a remember-me token that still works and an
outstanding password reset token for an address that is no longer its own.

The new test reads the list from the schema instead of writing it down a third
time, so a table added by a future migration is covered on the day it appears
without anybody remembering to come back. It also asserts the two paths agree
with each other: they were two hand-maintained copies of one list, which is how
they drifted together and how they would drift apart.

Scope is deliberately the coverage and nothing else. These paths also delete
the user row first, discard every result and use no transaction; that is a
second defect, it needs a different change, and bundling it would turn a
mechanical diff into a design discussion.

One thing this does not do: uploaded_avatars loses its row, not its file. The
files on disk are a separate question and left alone here.
