### PR TITLE
fix(auth): do not report 2FA as enabled when the enrolment did not complete

### DIFF
--- a/endpoints/user/enable_totp.php
+++ b/endpoints/user/enable_totp.php
@@ -94,26 +94,67 @@ if ($action === 'verify') {
                 $backupCodes[] = $backupCode;
             }
 
-            // Remove old TOTP data
-            $stmt = $db->prepare("DELETE FROM totp WHERE user_id = :user_id");
-            $stmt->bindValue(':user_id', $userId, SQLITE3_INTEGER);
-            $stmt->execute();
+            // The enrolment row and the flag on the account have to agree, so
+            // the three writes are one unit of work and each result is read.
+            //
+            // The state to avoid is totp_enabled = 1 with no row in totp: an
+            // account in it cannot be logged into by any credential at all.
+            // login.php sends the person to totp.php, which then has no secret
+            // and no backup codes to check against, so neither an authenticator
+            // code nor any of the ten backup codes they have just been shown
+            // will ever work again. Before this, all three writes were
+            // discarded and success was reported unconditionally, so that
+            // account was told 2FA was on and given the codes to prove it.
+            $enrolled = $db->exec('BEGIN') !== false;
 
-            $stmt = $db->prepare("INSERT INTO totp (user_id, totp_secret, backup_codes, last_totp_used) VALUES (:user_id, :totp_secret, :backup_codes, :last_totp_used)");
-            $stmt->bindValue(':user_id', $userId, SQLITE3_INTEGER);
-            $stmt->bindValue(':totp_secret', $secret, SQLITE3_TEXT);
-            $stmt->bindValue(':backup_codes', json_encode($backupCodes), SQLITE3_TEXT);
-            // Store the current TOTP time-step (not a raw timestamp): the code
-            // just verified above counts as used, so it cannot be replayed as the
-            // first login code. totp.php compares against this same step counter.
-            $stmt->bindValue(':last_totp_used', intdiv(time(), 30), SQLITE3_INTEGER);
-            $stmt->execute();
+            if ($enrolled) {
+                $stmt = $db->prepare("DELETE FROM totp WHERE user_id = :user_id");
+                $enrolled = $stmt !== false;
+
+                if ($enrolled) {
+                    $stmt->bindValue(':user_id', $userId, SQLITE3_INTEGER);
+                    $enrolled = $stmt->execute() !== false;
+                }
+            }
+
+            if ($enrolled) {
+                $stmt = $db->prepare("INSERT INTO totp (user_id, totp_secret, backup_codes, last_totp_used) VALUES (:user_id, :totp_secret, :backup_codes, :last_totp_used)");
+                $enrolled = $stmt !== false;
+
+                if ($enrolled) {
+                    $stmt->bindValue(':user_id', $userId, SQLITE3_INTEGER);
+                    $stmt->bindValue(':totp_secret', $secret, SQLITE3_TEXT);
+                    $stmt->bindValue(':backup_codes', json_encode($backupCodes), SQLITE3_TEXT);
+                    // Store the current TOTP time-step (not a raw timestamp): the code
+                    // just verified above counts as used, so it cannot be replayed as the
+                    // first login code. totp.php compares against this same step counter.
+                    $stmt->bindValue(':last_totp_used', intdiv(time(), 30), SQLITE3_INTEGER);
+                    $enrolled = $stmt->execute() !== false;
+                }
+            }
 
             // Update user totp_enabled
+            if ($enrolled) {
+                $stmt = $db->prepare("UPDATE user SET totp_enabled = 1 WHERE id = :user_id");
+                $enrolled = $stmt !== false;
 
-            $stmt = $db->prepare("UPDATE user SET totp_enabled = 1 WHERE id = :user_id");
-            $stmt->bindValue(':user_id', $userId, SQLITE3_INTEGER);
-            $stmt->execute();
+                if ($enrolled) {
+                    $stmt->bindValue(':user_id', $userId, SQLITE3_INTEGER);
+                    $enrolled = $stmt->execute() !== false;
+                }
+            }
+
+            if (!$enrolled || $db->exec('COMMIT') === false) {
+                $db->exec('ROLLBACK');
+
+                error_log('Wallos: could not enable 2FA for user ' . (int) $userId
+                    . ', nothing was changed: ' . $db->lastErrorMsg());
+
+                die(json_encode([
+                    "success" => false,
+                    "message" => translate('error', $i18n)
+                ]));
+            }
 
             die(json_encode([
                 "success" => true,

--- a/tests/cases/totp_enrolment_test.php
+++ b/tests/cases/totp_enrolment_test.php
@@ -1,0 +1,94 @@
+<?php
+/*
+  Enabling 2FA is one unit of work, or it is nothing.
+
+  The state this exists to prevent is `user.totp_enabled = 1` with no row in
+  `totp`. An account in it cannot be logged into by any credential: login.php
+  sends the person to totp.php, which then has no secret and no backup codes to
+  check against. Neither an authenticator code nor any of the ten backup codes
+  they were just shown will ever work.
+
+  Before the fix all three writes were discarded and `success: true` was
+  reported unconditionally, so the account that had just been locked out was
+  told 2FA was on and handed the codes to prove it.
+*/
+
+/**
+ * The enrolment endpoint's source.
+ *
+ * @return string
+ */
+function totp_enrolment_source()
+{
+    return file_get_contents(WALLOS_ROOT . '/endpoints/user/enable_totp.php');
+}
+
+wallos_test('the enrolment writes are one transaction', function () {
+    $source = totp_enrolment_source();
+
+    assert_contains("'BEGIN'", $source, 'the enrolment opens a transaction');
+    assert_contains("'COMMIT'", $source, 'and commits it');
+    assert_contains("'ROLLBACK'", $source, 'and rolls back when a write fails');
+});
+
+wallos_test('no write in the enrolment is discarded', function () {
+    // The defect was not a missing transaction alone. Each of the three writes
+    // returned a result nobody read, so a transaction that was never told to
+    // roll back would have committed the broken state just as happily.
+    $source = totp_enrolment_source();
+    $lines = preg_split('/\R/', $source);
+    $discarded = [];
+
+    foreach ($lines as $number => $line) {
+        // A result is used when it is assigned, compared or returned. A
+        // statement on a line of its own is a result thrown away.
+        if (preg_match('/^\s*\$stmt->execute\(\)\s*;\s*$/', $line) === 1) {
+            $discarded[] = $number + 1;
+        }
+    }
+
+    assert_same([], $discarded,
+        'every execute() in enable_totp.php is read (lines with a discarded one: '
+        . implode(', ', $discarded) . ')');
+});
+
+wallos_test('a rolled back enrolment leaves the account exactly as it was', function () {
+    // The guarantee the fix rests on, checked against the real schema rather
+    // than assumed: the rollback has to cover both tables, or the account is
+    // left in the state above.
+    $db = wallos_test_open_database();
+    wallos_test_create_user($db, 1, 'alice');
+
+    $db->exec('BEGIN');
+
+    $stmt = $db->prepare('DELETE FROM totp WHERE user_id = :userId');
+    $stmt->bindValue(':userId', 1, SQLITE3_INTEGER);
+    $stmt->execute();
+
+    $stmt = $db->prepare('INSERT INTO totp (user_id, totp_secret, backup_codes, last_totp_used)
+                          VALUES (:userId, :secret, :codes, :step)');
+    $stmt->bindValue(':userId', 1, SQLITE3_INTEGER);
+    $stmt->bindValue(':secret', 'SECRET', SQLITE3_TEXT);
+    $stmt->bindValue(':codes', json_encode(['a', 'b']), SQLITE3_TEXT);
+    $stmt->bindValue(':step', intdiv(time(), 30), SQLITE3_INTEGER);
+    $stmt->execute();
+
+    $stmt = $db->prepare('UPDATE user SET totp_enabled = 1 WHERE id = :userId');
+    $stmt->bindValue(':userId', 1, SQLITE3_INTEGER);
+    $stmt->execute();
+
+    // Both halves are in place inside the transaction.
+    assert_same(1, (int) $db->querySingle('SELECT COUNT(*) FROM totp WHERE user_id = 1'),
+        'the enrolment row exists before the rollback');
+    assert_same(1, (int) $db->querySingle('SELECT totp_enabled FROM user WHERE id = 1'),
+        'and so does the flag');
+
+    $db->exec('ROLLBACK');
+
+    assert_same(0, (int) $db->querySingle('SELECT COUNT(*) FROM totp WHERE user_id = 1'),
+        'the enrolment row is gone again');
+    assert_same(0, (int) $db->querySingle('SELECT totp_enabled FROM user WHERE id = 1'),
+        'and the flag with it — neither half survives alone');
+
+    $db->close();
+});

--- a/tests/cases/totp_enrolment_test.php
+++ b/tests/cases/totp_enrolment_test.php
@@ -88,7 +88,7 @@ wallos_test('a rolled back enrolment leaves the account exactly as it was', func
     assert_same(0, (int) $db->querySingle('SELECT COUNT(*) FROM totp WHERE user_id = 1'),
         'the enrolment row is gone again');
     assert_same(0, (int) $db->querySingle('SELECT totp_enabled FROM user WHERE id = 1'),
-        'and the flag with it — neither half survives alone');
+        'and the flag with it, neither half survives alone');
 
     $db->close();
 });


### PR DESCRIPTION
Enabling 2FA writes three times — delete any previous enrolment, insert the
new secret and backup codes, set totp_enabled on the account — and none of the
three results was read. There was no transaction. Then success was reported
unconditionally, together with the ten backup codes.

The state that produces is totp_enabled = 1 with no row in totp, and an
account in it cannot be logged into by any credential at all: login.php sends
the person to totp.php, which then has no secret and no backup codes to check
against. Neither an authenticator code nor any of the ten codes they have just
been shown will ever work again. They have no reason to suspect anything —
they were told 2FA is on and handed the proof.

The three writes are now one transaction and each result is read. A failure
rolls back and answers with the existing 'error' string, so the account is left
exactly as it was and the person can try again. exec('BEGIN'/'COMMIT'/
'ROLLBACK') rather than a helper, so this needs nothing the file does not
already have.

tests/cases/totp_enrolment_test.php checks three things: that the transaction
is there, that no execute() in the file is discarded — a transaction nobody
tells to roll back commits the broken state just as happily — and, against the
real schema rather than by assumption, that a rollback takes both halves with
it and cannot leave the flag standing without the row.

Checked by putting the old file back: the guard names the three lines whose
results were dropped.
