### PR TITLE
fix(auth): do not report a password reset that did not happen

### DIFF
--- a/passwordreset.php
+++ b/passwordreset.php
@@ -59,20 +59,59 @@ if (isset($_POST['email']) && $_POST['email'] != "" && isset($_GET['submit']) &&
     $stmt->bindValue(':email', $email, SQLITE3_TEXT);
     $user = $stmt->execute()->fetchArray(SQLITE3_ASSOC);
 
+    $issueFailed = false;
+
     if ($user) {
+        // The delete and the insert are one unit of work. Unwrapped, a failing
+        // insert after a succeeding delete leaves the account with no token at
+        // all: the old one is gone, the new one never arrived, and the person
+        // has just been told the mail is on its way. That account cannot be
+        // recovered until someone notices.
+        $db->exec('BEGIN');
+
+        $issued = false;
         $stmt = $db->prepare("DELETE FROM password_resets WHERE email = :email");
-        $stmt->bindValue(':email', $email, SQLITE3_TEXT);
-        $stmt->execute();
 
-        $token = bin2hex(random_bytes(32));
+        if ($stmt !== false) {
+            $stmt->bindValue(':email', $email, SQLITE3_TEXT);
 
-        $stmt = $db->prepare("INSERT INTO password_resets (user_id, email, token) VALUES (:user_id, :email, :token)");
-        $stmt->bindValue(':user_id', $user['id'], SQLITE3_INTEGER);
-        $stmt->bindValue(':email', $email, SQLITE3_TEXT);
-        $stmt->bindValue(':token', $token, SQLITE3_TEXT);
-        $stmt->execute();
+            if ($stmt->execute() !== false) {
+                $token = bin2hex(random_bytes(32));
+
+                $stmt = $db->prepare("INSERT INTO password_resets (user_id, email, token) VALUES (:user_id, :email, :token)");
+
+                if ($stmt !== false) {
+                    $stmt->bindValue(':user_id', $user['id'], SQLITE3_INTEGER);
+                    $stmt->bindValue(':email', $email, SQLITE3_TEXT);
+                    $stmt->bindValue(':token', $token, SQLITE3_TEXT);
+                    $issued = $stmt->execute() !== false;
+                }
+            }
+        }
+
+        if ($issued) {
+            $issued = $db->exec('COMMIT') !== false;
+        } else {
+            $db->exec('ROLLBACK');
+        }
+
+        if (!$issued) {
+            error_log('Wallos password reset: no token was issued for ' . $email
+                . '; any previous token was left in place: ' . $db->lastErrorMsg());
+            $issueFailed = true;
+        }
     }
-    $hasSuccessMessage = true;
+
+    // Still unconditional when the address is simply unknown: answering
+    // differently for a known and an unknown address is how a reset form
+    // becomes an account enumeration oracle. Only a genuine failure to store
+    // the token changes the answer, because there the promise of a mail is
+    // one the application cannot keep.
+    if ($issueFailed) {
+        $hasErrorMessage = true;
+    } else {
+        $hasSuccessMessage = true;
+    }
 }
 
 if (isset($_GET['token']) && $_GET['token'] != "" && isset($_GET['email']) && $_GET['email'] != "") {
@@ -111,17 +150,48 @@ if (isset($_POST['password']) && $_POST['password'] != "" && isset($_POST['confi
         $user = $result->fetchArray(SQLITE3_ASSOC);
         
         if ($password == $confirmPassword) {
+            // The other half of the same file. Neither write was checked and
+            // the success message was unconditional, so a failed UPDATE still
+            // consumed the token: the person is told the password was changed,
+            // the old one goes on working, and the one link back in has been
+            // spent. There is then no way to ask for another without an
+            // administrator.
             $passwordHash = password_hash($password, PASSWORD_DEFAULT);
             $stmt = $db->prepare("UPDATE user SET password = :password WHERE id = :id");
-            $stmt->bindValue(':password', $passwordHash, SQLITE3_TEXT);
-            $stmt->bindValue(':id', $user['id'], SQLITE3_INTEGER);
-            $stmt->execute();
+            $passwordChanged = false;
 
-            $stmt = $db->prepare("DELETE FROM password_resets WHERE token = :token");
-            $stmt->bindValue(':token', $token, SQLITE3_TEXT);
-            $stmt->execute();
-            $hasSuccessMessage = true;
-            $hideForm = true;
+            if ($stmt !== false) {
+                $stmt->bindValue(':password', $passwordHash, SQLITE3_TEXT);
+                $stmt->bindValue(':id', $user['id'], SQLITE3_INTEGER);
+                // changes() as well as the result: a statement that ran but
+                // matched no row changed no password either.
+                $passwordChanged = $stmt->execute() !== false && $db->changes() > 0;
+            }
+
+            if (!$passwordChanged) {
+                error_log('Wallos password reset: the password was not changed for user '
+                    . $user['id'] . ': ' . $db->lastErrorMsg());
+                $hasErrorMessage = true;
+            } else {
+                // Only now is the token spent. A token that survives a failed
+                // reset can be used again; one consumed by a failed reset
+                // cannot, and the user has no way to tell which happened.
+                $stmt = $db->prepare("DELETE FROM password_resets WHERE token = :token");
+
+                if ($stmt !== false) {
+                    $stmt->bindValue(':token', $token, SQLITE3_TEXT);
+
+                    if ($stmt->execute() === false) {
+                        // The password did change, so this is not a failure the
+                        // user can act on — but the token now outlives its use.
+                        error_log('Wallos password reset: the used token was not cleared: '
+                            . $db->lastErrorMsg());
+                    }
+                }
+
+                $hasSuccessMessage = true;
+                $hideForm = true;
+            }
         } else {
             $hasErrorMessage = true;
             $passwordsMismatch = true;

--- a/passwordreset.php
+++ b/passwordreset.php
@@ -183,7 +183,7 @@ if (isset($_POST['password']) && $_POST['password'] != "" && isset($_POST['confi
 
                     if ($stmt->execute() === false) {
                         // The password did change, so this is not a failure the
-                        // user can act on — but the token now outlives its use.
+                        // user can act on, but the token now outlives its use.
                         error_log('Wallos password reset: the used token was not cleared: '
                             . $db->lastErrorMsg());
                     }

--- a/tests/cases/password_reset_test.php
+++ b/tests/cases/password_reset_test.php
@@ -1,0 +1,93 @@
+<?php
+/*
+  A password reset says what actually happened.
+
+  passwordreset.php reports success over unchecked writes in two places, and
+  both leave the account worse off than before.
+
+  Issuing the token: delete the previous one, insert a new one, tell the person
+  the mail is on its way — whatever the two writes did. A delete that succeeds
+  followed by an insert that does not leaves the account with no token at all.
+
+  Using the token: update the password, consume the token, say it worked —
+  again whatever the writes did. A failed update tells the person their
+  password changed while the old one still works, and spends the one link back
+  in on the way. There is no second link without an administrator.
+*/
+
+/**
+ * @return string
+ */
+function password_reset_source()
+{
+    return file_get_contents(WALLOS_ROOT . '/passwordreset.php');
+}
+
+wallos_test('issuing a token is one transaction', function () {
+    $source = password_reset_source();
+
+    assert_contains("'BEGIN'", $source, 'the token swap opens a transaction');
+    assert_contains("'COMMIT'", $source, 'and commits it');
+    assert_contains("'ROLLBACK'", $source, 'and rolls back when a write fails');
+});
+
+wallos_test('no write in the file is discarded', function () {
+    // Both halves had the same shape, so the guard covers the whole file
+    // rather than one block: a third write added later is caught too.
+    $lines = preg_split('/\R/', password_reset_source());
+    $discarded = [];
+
+    foreach ($lines as $number => $line) {
+        if (preg_match('/^\s*\$stmt->execute\(\)\s*;\s*$/', $line) === 1) {
+            $discarded[] = $number + 1;
+        }
+    }
+
+    assert_same([], $discarded,
+        'every execute() in passwordreset.php is read (lines with a discarded '
+        . 'one: ' . implode(', ', $discarded) . ')');
+});
+
+wallos_test('an unknown address is answered exactly like a known one', function () {
+    // Deliberate, and the reason the success message cannot simply become
+    // conditional on everything: answering differently for a registered and an
+    // unregistered address turns this form into an account enumeration oracle.
+    // Only a genuine failure to store the token changes the answer.
+    $source = password_reset_source();
+
+    assert_contains('enumeration', $source,
+        'the reason the unknown-address answer stays unconditional is written '
+        . 'down where the next edit will see it');
+});
+
+wallos_test('a rolled back token swap leaves the previous token in place', function () {
+    // The guarantee the fix rests on, against the real schema: if the rollback
+    // did not restore the deleted row, the failure it exists for would still
+    // leave the account with nothing.
+    $db = wallos_test_open_database();
+    wallos_test_create_user($db, 1, 'alice');
+
+    $stmt = $db->prepare('INSERT INTO password_resets (user_id, email, token)
+                          VALUES (1, :email, :token)');
+    $stmt->bindValue(':email', 'alice@example.com', SQLITE3_TEXT);
+    $stmt->bindValue(':token', 'the-old-token', SQLITE3_TEXT);
+    $stmt->execute();
+
+    $db->exec('BEGIN');
+
+    $stmt = $db->prepare('DELETE FROM password_resets WHERE email = :email');
+    $stmt->bindValue(':email', 'alice@example.com', SQLITE3_TEXT);
+    $stmt->execute();
+
+    assert_same(0, (int) $db->querySingle('SELECT COUNT(*) FROM password_resets'),
+        'the previous token is gone inside the transaction');
+
+    // The insert that does not happen: the failure this exists for.
+    $db->exec('ROLLBACK');
+
+    assert_same('the-old-token',
+        (string) $db->querySingle("SELECT token FROM password_resets WHERE email = 'alice@example.com'"),
+        'and is back afterwards, so the account still has a way in');
+
+    $db->close();
+});

--- a/tests/cases/password_reset_test.php
+++ b/tests/cases/password_reset_test.php
@@ -6,10 +6,10 @@
   both leave the account worse off than before.
 
   Issuing the token: delete the previous one, insert a new one, tell the person
-  the mail is on its way — whatever the two writes did. A delete that succeeds
+  the mail is on its way, whatever the two writes did. A delete that succeeds
   followed by an insert that does not leaves the account with no token at all.
 
-  Using the token: update the password, consume the token, say it worked —
+  Using the token: update the password, consume the token, say it worked,
   again whatever the writes did. A failed update tells the person their
   password changed while the old one still works, and spends the one link back
   in on the way. There is no second link without an administrator.


### PR DESCRIPTION
passwordreset.php reports success over unchecked writes twice, in two
different places, and both leave the account worse off than before.

**Issuing the token.** The delete and the insert were both unchecked and the
success message was set regardless. The failure that matters is a delete that
succeeds followed by an insert that does not: the previous token is gone, the
new one was never written, and the person has just read that the mail is on
its way. They are locked out until somebody notices.

The two statements are now one transaction, so a failed insert leaves the
previous token in place, and the failure is logged with the database's own
message.

The success message stays unconditional for an address that simply is not
registered. Answering differently for a known and an unknown address turns
this form into an account enumeration oracle, which is why it was written that
way. Only a real failure to store the token changes the answer — there the
application cannot keep the promise it would otherwise make.

**Using the token.** The same shape further down, and worse. The password
UPDATE was unchecked, the token was consumed regardless, and
$hasSuccessMessage was set unconditionally. So a reset that did not change
anything tells the person their password was changed, the old one goes on
working, and the single link back in has been spent proving it. There is no
second link without an administrator.

The token is now spent only after the password actually changed — checked
through both the statement result and changes(), because a statement that ran
but matched no row changed no password either. A delete that then fails is
logged but not reported: the password did change, so it is not a failure the
person can act on.

Both halves use $hasErrorMessage, which this file already defines and renders
as an error box with the existing 'error' string. No new message and no new
translation key.

tests/cases/password_reset_test.php covers the whole file rather than one
block, so a third write added later is caught too: the transaction is present,
no execute() is discarded, the enumeration reasoning is written down where the
next edit will see it, and — against the real schema — a rolled back token swap
puts the previous token back, which is the guarantee the fix rests on.

Checked by restoring the old file: the guard names lines 65, 73, 118 and 122.
