### PR TITLE
fix: sort categories by the column, not by the string "order"

### DIFF
--- a/includes/stats_calculations.php
+++ b/includes/stats_calculations.php
@@ -29,7 +29,7 @@ function getPriceConverted($price, $currency, $database, $userId)
 
 // Get categories
 $categories = array();
-$query = "SELECT * FROM categories WHERE user_id = :userId ORDER BY 'order' ASC";
+$query = "SELECT * FROM categories WHERE user_id = :userId ORDER BY `order` ASC";
 $stmt = $db->prepare($query);
 $stmt->bindValue(':userId', $userId, SQLITE3_INTEGER);
 $result = $stmt->execute();

--- a/tests/cases/order_by_test.php
+++ b/tests/cases/order_by_test.php
@@ -1,0 +1,55 @@
+<?php
+/*
+  ORDER BY names a column, not a string.
+
+  `ORDER BY 'order'` sorts by a constant. Every row gets the same sort key, so
+  SQLite returns them in whatever order it happens to have them and the list
+  looks unsorted for no visible reason — the statement is valid, nothing warns,
+  and the column the user drags into place is never consulted.
+
+  The same query is written four other times in this codebase, all four with
+  the column quoted as an identifier. This checks that they stay that way, and
+  that a fifth is not written the other way.
+
+  The rule is general on purpose: `ORDER BY '<anything>'` is a constant, and
+  sorting by a constant is never what anybody means.
+*/
+
+wallos_test('no query sorts by a string constant', function () {
+    $offenders = [];
+    $checked = 0;
+
+    $directory = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator(WALLOS_ROOT, RecursiveDirectoryIterator::SKIP_DOTS));
+
+    foreach ($directory as $file) {
+        $path = str_replace(WALLOS_ROOT . '/', '', $file->getPathname());
+
+        if ($file->getExtension() !== 'php'
+            || strpos($path, 'libs/') === 0
+            || strpos($path, 'tests/') === 0) {
+            continue;
+        }
+
+        foreach (preg_split('/\R/', file_get_contents($file->getPathname())) as $number => $line) {
+            if (stripos($line, 'ORDER BY') === false) {
+                continue;
+            }
+
+            $checked++;
+
+            // A single-quoted token straight after ORDER BY is a constant. An
+            // identifier is bare, backticked or double-quoted.
+            if (preg_match("/ORDER\s+BY\s+'/i", $line) === 1) {
+                $offenders[] = $path . ':' . ($number + 1) . ' — ' . trim($line);
+            }
+        }
+    }
+
+    // A guard that finds nothing passes its own assertion.
+    assert_true($checked >= 5,
+        'the ORDER BY clauses were found (' . $checked . ' lines)');
+
+    assert_same([], $offenders,
+        'no ORDER BY sorts by a constant: ' . implode(' | ', $offenders));
+});

--- a/tests/cases/order_by_test.php
+++ b/tests/cases/order_by_test.php
@@ -4,7 +4,7 @@
 
   `ORDER BY 'order'` sorts by a constant. Every row gets the same sort key, so
   SQLite returns them in whatever order it happens to have them and the list
-  looks unsorted for no visible reason — the statement is valid, nothing warns,
+  looks unsorted for no visible reason: the statement is valid, nothing warns,
   and the column the user drags into place is never consulted.
 
   The same query is written four other times in this codebase, all four with
@@ -41,7 +41,7 @@ wallos_test('no query sorts by a string constant', function () {
             // A single-quoted token straight after ORDER BY is a constant. An
             // identifier is bare, backticked or double-quoted.
             if (preg_match("/ORDER\s+BY\s+'/i", $line) === 1) {
-                $offenders[] = $path . ':' . ($number + 1) . ' — ' . trim($line);
+                $offenders[] = $path . ':' . ($number + 1) . ' - ' . trim($line);
             }
         }
     }


### PR DESCRIPTION
`includes/stats_calculations.php:32` reads

    ORDER BY 'order' ASC

which sorts by a string constant. Every row gets the same sort key, so the
categories come back in whatever order SQLite happens to have them, and the
order the user dragged them into is never consulted. The statement is valid and
nothing warns, which is why the statistics page has looked unsorted for a long
time with no obvious cause.

The same query is written four other times in this codebase — `getdbkeys.php`
lines 25 and 36, `settings.php` lines 913 and 1336 — and all four quote the
column as an identifier. This makes the fifth match them, using the same
backticks rather than introducing a second style.

tests/cases/order_by_test.php keeps it that way. The rule is general rather
than about this one line: a single-quoted token straight after ORDER BY is a
constant, and sorting by a constant is never what anybody means. It counts the
clauses it examined, so it cannot pass by finding nothing.

Checked by putting the old line back: it fails and prints the file, the line
number and the statement.
