### PR TITLE
ci: don't attempt registry login on pull_request builds (fork PRs fail the build check)

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -66,12 +66,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.REGISTRY_USERNAME }}
           password: ${{ env.REGISTRY_PASSWORD }}
       - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io


### PR DESCRIPTION
The `build` job logs in to Docker Hub as its first step, using
`secrets.DOCKERHUB_USERNAME` / `secrets.DOCKERHUB_TOKEN`. GitHub does not pass
repository secrets to workflows triggered by `pull_request` from a fork, so those
values are empty and `docker/login-action` fails with `Username and password
required` before the image is ever built. Every fork PR's
`build (linux/amd64|arm64|arm/v7)` check fails in a few seconds, before QEMU,
Buildx or the build itself ever run.

The push is already correctly gated to non-PR events
(`push=${{ github.event_name != 'pull_request' }}`, and the digest export/upload
steps and the whole `merge` job carry `if: github.event_name != 'pull_request'`),
so no registry login is needed on a PR. This change adds
`if: github.event_name != 'pull_request'` to the two login steps in the `build`
job. Pull requests now run the full multi-arch build as a build-only check (no
push, no login); pushes to branches and releases are unaffected and still log in
and push exactly as before.

Note: because `pull_request` workflows run from the base branch, this takes
effect for runs after it is merged; the existing red PR checks can then be
re-run to go green.
