### PR TITLE
fix(notifications): keep a note that ends in a quotation mark from breaking the webhook payload

### DIFF
--- a/includes/webhook_helper.php
+++ b/includes/webhook_helper.php
@@ -5,17 +5,29 @@
  * str_replace() templating (the webhook payload template uses
  * "{{placeholder}}" substitution, not real JSON building).
  *
- * Notes can now be multi-line Markdown containing quotes/backslashes, which
- * would otherwise break the payload's JSON structure - json_encode() quotes
- * and escapes the value correctly; the surrounding quotes it adds are
- * trimmed off since the template already supplies them.
+ * Notes can now be multi-line Markdown containing quotes and backslashes, which
+ * would otherwise break the payload's JSON structure. json_encode() quotes and
+ * escapes the value correctly; the template already supplies the surrounding
+ * quotes, so they have to come off again.
+ *
+ * The two characters json_encode() added, and only those. trim($encoded, '"')
+ * strips *every* leading and trailing quote character, so a value ending in a
+ * quotation mark lost the closing quote of its own \" escape and left a bare
+ * backslash at the end of the payload's string - which stops being JSON. A note
+ * reading He said "hi" is enough; it came out as He said \"hi\ and every
+ * webhook for that subscription was sent as a body the receiver cannot parse.
  *
  * @param string $value
  * @return string
  */
 function webhookJsonEscape($value)
 {
-    return trim(json_encode((string) $value), '"');
+    $encoded = json_encode((string) $value);
+
+    // json_encode() answers false only for input it cannot represent, which a
+    // string this function has already cast cannot be - but an empty value is
+    // the safe answer rather than the literal "false".
+    return $encoded === false ? '' : substr($encoded, 1, -1);
 }
 
 ?>

--- a/tests/cases/notes_markdown_test.php
+++ b/tests/cases/notes_markdown_test.php
@@ -91,6 +91,33 @@ wallos_test('webhookJsonEscape() keeps a multi-line note from breaking the paylo
     assert_same($note, $decoded['notes'] ?? null, 'and decodes back to the exact original note');
 });
 
+wallos_test('a note that ends in a quotation mark survives the escape', function () {
+    // The one the helper as written could not do. trim($encoded, '"') strips
+    // every leading and trailing quote character, not the two json_encode()
+    // added, so a value ending in a quotation mark lost the closing quote of
+    // its own \\" escape and left the payload ending in a bare backslash. He
+    // said "hi" is enough: it came out as He said \\"hi\\ and the body was no
+    // longer JSON, so the receiver rejected every webhook for that
+    // subscription. The first and last character are exactly where a "strip
+    // the quotes" implementation goes wrong, so they are what this asks about.
+    $notes = [
+        'a note ending in a quote' => 'cancel "soon"',
+        'a note that is one quote' => '"',
+        'a note quoted end to end' => '"quoted"',
+        'a note ending in a backslash' => 'path\\',
+        'a note that is empty' => '',
+    ];
+
+    foreach ($notes as $label => $note) {
+        $payload = '{"notes": "' . webhookJsonEscape($note) . '"}';
+        $decoded = json_decode($payload, true);
+
+        assert_true($decoded !== null, $label . ' produces valid JSON: ' . $payload);
+        assert_same($note, $decoded['notes'] ?? null,
+            $label . ' decodes back to exactly what was written');
+    }
+});
+
 wallos_test('both notification crons use the shared webhookJsonEscape() helper for notes', function () {
     foreach (['endpoints/cronjobs/sendnotifications.php', 'endpoints/cronjobs/sendcancellationnotifications.php'] as $file) {
         $source = file_get_contents(WALLOS_ROOT . '/' . $file);


### PR DESCRIPTION
`webhookJsonEscape()` removes the quotes `json_encode()` adds with
`trim($encoded, '"')`, and `trim()` with a character mask strips *every* leading
and trailing quote character rather than one at each end. A value that ends in a
quotation mark therefore loses the closing quote of its own `\"` escape:

```
note     He said "hi"
escaped  He said \"hi\
payload  {"notes": "He said \"hi\"}      json_decode(): syntax error
```

A note reading `cancel "soon"` is enough. Every webhook for that subscription is
then sent with a body the receiver cannot parse, and nothing on any screen says
so — the request goes out, it is simply not JSON. A note consisting of a single
quotation mark escapes to a bare backslash, which is the same failure in its
shortest form.

`substr($encoded, 1, -1)` removes the two characters `json_encode()` actually
added, whatever the value contains.

### Reproducing it

```php
require 'includes/webhook_helper.php';

foreach (['Family plan', 'cancel "soon"', '"', 'path\\'] as $note) {
    $payload = '{"notes": "' . webhookJsonEscape($note) . '"}';
    printf("%-16s %s\n", $note, json_decode($payload, true) === null ? 'BROKEN' : 'ok');
}
```

Before: `Family plan ok`, `cancel "soon" BROKEN`, `" BROKEN`, `path\ ok`.
After: all four ok, and each decodes back to exactly what was written.

### Test

The existing case for this helper passes either way, because the note it uses
ends in `- Bob`. The one added here asks about the first and the last character,
which is where a "strip the quotes" implementation goes wrong: a note ending in
a quote, a note that is one quote, a note quoted end to end, a note ending in a
backslash, and an empty note. All five fail with the previous line in place.
