### PR TITLE
fix(i18n): an account an identity provider creates is in the language it named

### DIFF
--- a/includes/i18n/getlang.php
+++ b/includes/i18n/getlang.php
@@ -1,17 +1,10 @@
 <?php
 
-$lang = "en";
-if (isset($_COOKIE['language'])) {
-    $selectedLanguage = $_COOKIE['language'];
-
-    if (array_key_exists($selectedLanguage, $langname_corrections)) {
-        $selectedLanguage = $langname_corrections[$selectedLanguage];
-    }
-
-    if (array_key_exists($selectedLanguage, $languages)) {
-        $lang = $selectedLanguage;
-    }
-}
+// resolve_language() is strictly more permissive than the two lookups this
+// used to do: every value that worked before still answers the same file, and a
+// tag that did not - "de-DE" from a browser, "pt-BR" from an identity provider -
+// now answers one instead of silently falling back to English.
+$lang = isset($_COOKIE['language']) ? resolve_language($_COOKIE['language']) : "en";
 
 function translate($text, $translations)
 {

--- a/includes/i18n/languages.php
+++ b/includes/i18n/languages.php
@@ -37,3 +37,70 @@ $languages = [
 $langname_corrections = [
     "jp" => "ja",
 ];
+
+/**
+ * Turns any language value into one of the keys of $languages above.
+ *
+ * The keys are file names - "pt_br", "zh_cn", "sr_lat" - and everything that
+ * hands Wallos a language hands it a BCP-47 tag instead: browsers send "de-DE"
+ * in Accept-Language, identity providers send "pt-BR" in the standard OIDC
+ * "locale" claim. Matching those against the keys directly fails, and the
+ * failure is silent - the account is simply English, and the person it happened
+ * to never chose that.
+ *
+ * What it accepts, in order:
+ *
+ *   an exact file name                      "de", "pt_br"
+ *   a name this project used before         "jp"      -> "ja"
+ *   a tag whose region names a file         "pt-BR"   -> "pt_br"
+ *   a tag whose script names a file         "zh-Hans" -> "zh_cn"
+ *   a tag whose language alone names a file "de-DE"   -> "de"
+ *
+ * Anything else answers "en", which is what the callers did before.
+ *
+ * @param string|null $value
+ * @return string a key of $languages
+ */
+function resolve_language($value)
+{
+    global $languages, $langname_corrections;
+
+    $normalized = strtolower(str_replace('-', '_', trim((string) $value)));
+
+    if ($normalized === '') {
+        return 'en';
+    }
+
+    if (isset($langname_corrections[$normalized])) {
+        $normalized = $langname_corrections[$normalized];
+    }
+
+    if (isset($languages[$normalized])) {
+        return $normalized;
+    }
+
+    // "zh-Hant" and "zh-Hans" name a script rather than a region, and the two
+    // Chinese files are keyed by the region their script is used in. Without
+    // this, traditional Chinese falls back to English whenever the sender
+    // spells it by script - and "zh" alone is not a file either.
+    $scripts = [
+        'zh_hans' => 'zh_cn',
+        'zh_hant' => 'zh_tw',
+        'sr_latn' => 'sr_lat',
+    ];
+
+    if (isset($scripts[$normalized])) {
+        return $scripts[$normalized];
+    }
+
+    // "de-DE", "en-GB", "pt-PT": the subtag after the language is a region
+    // nothing here is keyed by, so the language alone decides. "pt-BR" never
+    // reaches this line, because it matched a file name two checks ago.
+    $language = strtok($normalized, '_');
+
+    if ($language !== false && isset($languages[$language])) {
+        return $language;
+    }
+
+    return 'en';
+}

--- a/includes/oidc/oidc_create_user.php
+++ b/includes/oidc/oidc_create_user.php
@@ -7,7 +7,16 @@ $firstname = $parts[0] ?? '';
 $lastname = $parts[1] ?? '';
 
 // Defaults
-$language = 'en';
+//
+// The language comes from the provider when it named one. "locale" is a
+// standard OIDC claim and Authentik, Authelia and Keycloak all send it, so
+// hardcoding English here meant every account an identity provider created was
+// English whatever the provider said - and the person never saw the
+// registration form that would have asked them, because they never went
+// through it. resolve_language() answers 'en' when there is no claim or when
+// the claim names no translation, which is what this line did before.
+require_once __DIR__ . '/../i18n/languages.php';
+$language = resolve_language($userInfo['locale'] ?? null);
 $avatar = "images/avatars/0.svg";
 $budget = 0;
 $main_currency_id = 1; // Euro

--- a/tests/cases/language_resolution_test.php
+++ b/tests/cases/language_resolution_test.php
@@ -1,0 +1,133 @@
+<?php
+/*
+  A language value that is not already a file name still finds its translation.
+
+  The keys of $languages are file names — "pt_br", "zh_cn", "sr_lat" — and
+  nothing that hands Wallos a language hands it a file name. A browser sends
+  "de-DE" in Accept-Language. An identity provider sends "pt-BR" in the standard
+  OIDC "locale" claim. Matching either against the keys directly fails.
+
+  The failure is silent, which is what makes it worth a test rather than a
+  glance: there is no error, the account is simply in English. And for an
+  account an identity provider created there is no second chance to notice,
+  because the person never went through the registration form that would have
+  asked them for a language.
+
+  includes/oidc/oidc_create_user.php made that certain rather than likely: it
+  hardcoded 'en' and never looked at the claim at all.
+*/
+
+require_once WALLOS_ROOT . '/includes/i18n/languages.php';
+
+wallos_test('a file name resolves to itself', function () {
+    foreach (['en', 'de', 'ar', 'pt', 'pt_br', 'zh_cn', 'zh_tw', 'sr', 'sr_lat'] as $name) {
+        assert_same($name, resolve_language($name), $name . ' is already a translation file');
+    }
+});
+
+wallos_test('the identifiers this project used before still work', function () {
+    // The cookie of anybody who chose Japanese before it was renamed.
+    assert_same('ja', resolve_language('jp'), 'jp is the old name for ja');
+});
+
+wallos_test('a tag with a region resolves to the language', function () {
+    // What a browser sends in Accept-Language, and what most providers put in
+    // the locale claim.
+    $tags = [
+        'de-DE' => 'de',
+        'de-AT' => 'de',
+        'de-CH' => 'de',
+        'en-GB' => 'en',
+        'en-US' => 'en',
+        'pt-PT' => 'pt',
+        'fr-CA' => 'fr',
+        'es-MX' => 'es',
+        // A tag can carry a variant and a private-use section and still be a
+        // perfectly ordinary request for German.
+        'de-DE-1996-x-private' => 'de',
+    ];
+
+    foreach ($tags as $tag => $expected) {
+        assert_same($expected, resolve_language($tag), $tag . ' is ' . $expected);
+    }
+});
+
+wallos_test('a region that has its own translation keeps it', function () {
+    // pt-BR must not collapse to pt: both files exist and they are different
+    // translations, so answering the wrong one is worse than answering English.
+    assert_same('pt_br', resolve_language('pt-BR'), 'pt-BR has its own file');
+    assert_same('pt', resolve_language('pt'), 'and pt is still pt');
+    assert_same('zh_cn', resolve_language('zh-CN'), 'zh-CN has its own file');
+    assert_same('zh_tw', resolve_language('zh-TW'), 'zh-TW has its own file');
+});
+
+wallos_test('a tag that names a script rather than a region resolves too', function () {
+    // "zh-Hans" and "zh-Hant" are how the two Chinese written forms are named
+    // when the sender does not want to claim a country. Neither is a file, and
+    // "zh" alone is not one either, so without this both are English.
+    assert_same('zh_cn', resolve_language('zh-Hans'), 'simplified Chinese');
+    assert_same('zh_tw', resolve_language('zh-Hant'), 'traditional Chinese');
+    assert_same('sr_lat', resolve_language('sr-Latn'), 'Serbian in Latin script');
+});
+
+wallos_test('case and separator do not decide the answer', function () {
+    foreach (['DE', 'de-de', 'DE-DE', 'de_DE', 'PT-br', 'zh_HANS'] as $tag) {
+        $resolved = resolve_language($tag);
+
+        assert_true($resolved !== 'en' || strtolower($tag) === 'en',
+            $tag . ' resolves to a translation (got ' . $resolved . ')');
+    }
+
+    assert_same('de', resolve_language(' de-DE '), 'surrounding space is not part of the tag');
+});
+
+wallos_test('anything else answers English, as the callers did before', function () {
+    foreach (['', null, 'xx', 'not a language', 'xx-YY', '../en', 'en.php'] as $value) {
+        assert_same('en', resolve_language($value),
+            var_export($value, true) . ' names no translation');
+    }
+});
+
+wallos_test('every answer names a translation file that exists', function () {
+    // The guarantee the callers rest on: whatever comes back is included as
+    // 'i18n/' . $lang . '.php' a few lines later, so an answer that is not a
+    // file is a fatal error on every page.
+    global $languages;
+
+    $checked = 0;
+
+    foreach (array_keys($languages) as $name) {
+        foreach ([$name, str_replace('_', '-', $name), strtoupper($name)] as $spelling) {
+            $resolved = resolve_language($spelling);
+            $checked++;
+
+            assert_true(is_file(WALLOS_ROOT . '/includes/i18n/' . $resolved . '.php'),
+                $spelling . ' resolved to ' . $resolved . ', which has a translation file');
+            assert_true(is_file(WALLOS_ROOT . '/scripts/i18n/' . $resolved . '.js'),
+                $spelling . ' resolved to ' . $resolved . ', which has a script file');
+        }
+    }
+
+    // A guard that finds nothing passes every assertion above it.
+    assert_true($checked >= 60, 'every registered language was tried three ways (' . $checked . ')');
+});
+
+wallos_test('an account created by an identity provider is not hardcoded to English', function () {
+    // The defect this exists for. The claim is read, and 'en' is the fallback
+    // rather than the answer.
+    $source = file_get_contents(WALLOS_ROOT . '/includes/oidc/oidc_create_user.php');
+
+    assert_contains("resolve_language(\$userInfo['locale']", $source,
+        'the account language comes from the provider when it named one');
+    assert_true(preg_match("/^\\s*\\\$language\\s*=\\s*'en'\\s*;/m", $source) !== 1,
+        'and is not assigned a constant English');
+});
+
+wallos_test('the cookie goes through the same resolution', function () {
+    // Two places decide a language and they have to agree: an account created
+    // as "pt-BR" must not then be read back as English on the next request.
+    $source = file_get_contents(WALLOS_ROOT . '/includes/i18n/getlang.php');
+
+    assert_contains("resolve_language(\$_COOKIE['language'])", $source,
+        'the language cookie is resolved rather than matched against file names');
+});


### PR DESCRIPTION
`includes/oidc/oidc_create_user.php` assigns `$language = 'en'` and never looks
at the claims, so every account created through OIDC is English whatever the
provider said.

The person it happens to has no second chance to notice. They never went through
the registration form, so nothing ever asked them, and there is no error to see —
the application is simply in a language they did not choose. On a German or
Portuguese household running Keycloak or Authentik, everyone except the
administrator lands in English.

`locale` is a standard OIDC claim and the common providers send it. Reading it
needs one thing that was missing: the claim is a BCP-47 tag (`pt-BR`, `de-DE`)
and the keys of `$languages` are file names (`pt_br`, `de`), so matching one
against the other fails.

### `resolve_language()`

```
an exact file name                      "de", "pt_br"
a name this project used before         "jp"      -> "ja"
a tag whose region names a file         "pt-BR"   -> "pt_br"
a tag whose script names a file         "zh-Hans" -> "zh_cn"
a tag whose language alone names a file "de-DE"   -> "de"
```

Anything else answers `"en"`, which is what both call sites did before, so no
value that worked stops working. **Nothing is renamed** — the translation files
keep the names they have.

The order matters in one place, and the test says so: `pt-BR` has its own
translation and must not collapse to `pt`, and neither must `sr-Latn` to `sr`.
Answering the wrong translation would be worse than answering English.

`includes/i18n/getlang.php` goes through the same function rather than its two
lookups, so a language chosen once is read back the same way on the next
request — and a cookie holding `de-DE`, which a browser-language picker would
naturally write, now resolves instead of silently falling back.

### Test

`tests/cases/language_resolution_test.php` covers the table above, asserts that
every answer names a translation file *and* a script file that exist, and checks
both call sites. Verified by breaking it twice: putting the hardcoded `'en'`
back, and letting the language-only fallback run before the exact match so that
`pt-BR` collapses to `pt`.
