### PR TITLE
fix(i18n): a new account's categories are in the language it was created with

### DIFF
--- a/endpoints/admin/adduser.php
+++ b/endpoints/admin/adduser.php
@@ -1,6 +1,7 @@
 <?php
 require_once '../../includes/connect_endpoint.php';
 require_once '../../includes/validate_endpoint_admin.php';
+require_once '../../includes/default_names.php';
 
 $currencies = [
     ['id' => 1, 'name' => 'Euro', 'symbol' => '€', 'code' => 'EUR'],
@@ -37,60 +38,6 @@ $currencies = [
     ['id' => 32, 'name' => 'South African Rand', 'symbol' => 'R', 'code' => 'ZAR'],
     ['id' => 33, 'name' => 'Ukrainian Hryvnia', 'symbol' => '₴', 'code' => 'UAH'],
     ['id' => 34, 'name' => 'New Taiwan Dollar', 'symbol' => 'NT$', 'code' => 'TWD'],
-];
-
-$categories = [
-    ['id' => 1, 'name' => 'No category'],
-    ['id' => 2, 'name' => 'Entertainment'],
-    ['id' => 3, 'name' => 'Music'],
-    ['id' => 4, 'name' => 'Utilities'],
-    ['id' => 5, 'name' => 'Food & Beverages'],
-    ['id' => 6, 'name' => 'Health & Wellbeing'],
-    ['id' => 7, 'name' => 'Productivity'],
-    ['id' => 8, 'name' => 'Banking'],
-    ['id' => 9, 'name' => 'Transport'],
-    ['id' => 10, 'name' => 'Education'],
-    ['id' => 11, 'name' => 'Insurance'],
-    ['id' => 12, 'name' => 'Gaming'],
-    ['id' => 13, 'name' => 'News & Magazines'],
-    ['id' => 14, 'name' => 'Software'],
-    ['id' => 15, 'name' => 'Technology'],
-    ['id' => 16, 'name' => 'Cloud Services'],
-    ['id' => 17, 'name' => 'Charity & Donations'],
-];
-
-$payment_methods = [
-    ['id' => 1, 'name' => 'PayPal', 'icon' => 'images/uploads/icons/paypal.png'],
-    ['id' => 2, 'name' => 'Credit Card', 'icon' => 'images/uploads/icons/creditcard.png'],
-    ['id' => 3, 'name' => 'Bank Transfer', 'icon' => 'images/uploads/icons/banktransfer.png'],
-    ['id' => 4, 'name' => 'Direct Debit', 'icon' => 'images/uploads/icons/directdebit.png'],
-    ['id' => 5, 'name' => 'Money', 'icon' => 'images/uploads/icons/money.png'],
-    ['id' => 6, 'name' => 'Google Pay', 'icon' => 'images/uploads/icons/googlepay.png'],
-    ['id' => 7, 'name' => 'Samsung Pay', 'icon' => 'images/uploads/icons/samsungpay.png'],
-    ['id' => 8, 'name' => 'Apple Pay', 'icon' => 'images/uploads/icons/applepay.png'],
-    ['id' => 9, 'name' => 'Crypto', 'icon' => 'images/uploads/icons/crypto.png'],
-    ['id' => 10, 'name' => 'Klarna', 'icon' => 'images/uploads/icons/klarna.png'],
-    ['id' => 11, 'name' => 'Amazon Pay', 'icon' => 'images/uploads/icons/amazonpay.png'],
-    ['id' => 12, 'name' => 'SEPA', 'icon' => 'images/uploads/icons/sepa.png'],
-    ['id' => 13, 'name' => 'Skrill', 'icon' => 'images/uploads/icons/skrill.png'],
-    ['id' => 14, 'name' => 'Sofort', 'icon' => 'images/uploads/icons/sofort.png'],
-    ['id' => 15, 'name' => 'Stripe', 'icon' => 'images/uploads/icons/stripe.png'],
-    ['id' => 16, 'name' => 'Affirm', 'icon' => 'images/uploads/icons/affirm.png'],
-    ['id' => 17, 'name' => 'AliPay', 'icon' => 'images/uploads/icons/alipay.png'],
-    ['id' => 18, 'name' => 'Elo', 'icon' => 'images/uploads/icons/elo.png'],
-    ['id' => 19, 'name' => 'Facebook Pay', 'icon' => 'images/uploads/icons/facebookpay.png'],
-    ['id' => 20, 'name' => 'GiroPay', 'icon' => 'images/uploads/icons/giropay.png'],
-    ['id' => 21, 'name' => 'iDeal', 'icon' => 'images/uploads/icons/ideal.png'],
-    ['id' => 22, 'name' => 'Union Pay', 'icon' => 'images/uploads/icons/unionpay.png'],
-    ['id' => 23, 'name' => 'Interac', 'icon' => 'images/uploads/icons/interac.png'],
-    ['id' => 24, 'name' => 'WeChat', 'icon' => 'images/uploads/icons/wechat.png'],
-    ['id' => 25, 'name' => 'Paysafe', 'icon' => 'images/uploads/icons/paysafe.png'],
-    ['id' => 26, 'name' => 'Poli', 'icon' => 'images/uploads/icons/poli.png'],
-    ['id' => 27, 'name' => 'Qiwi', 'icon' => 'images/uploads/icons/qiwi.png'],
-    ['id' => 28, 'name' => 'ShopPay', 'icon' => 'images/uploads/icons/shoppay.png'],
-    ['id' => 29, 'name' => 'Venmo', 'icon' => 'images/uploads/icons/venmo.png'],
-    ['id' => 30, 'name' => 'VeriFone', 'icon' => 'images/uploads/icons/verifone.png'],
-    ['id' => 31, 'name' => 'WebMoney', 'icon' => 'images/uploads/icons/webmoney.png'],
 ];
 
 function validate($value)
@@ -176,8 +123,8 @@ if ($result) {
         // Add categories for that user
         $query = 'INSERT INTO categories (name, "order", user_id) VALUES (:name, :order, :user_id)';
         $stmt = $db->prepare($query);
-        foreach ($categories as $index => $category) {
-            $stmt->bindValue(':name', $category['name'], SQLITE3_TEXT);
+        foreach (default_categories($language) as $index => $name) {
+            $stmt->bindValue(':name', $name, SQLITE3_TEXT);
             $stmt->bindValue(':order', $index + 1, SQLITE3_INTEGER);
             $stmt->bindValue(':user_id', $newUserId, SQLITE3_INTEGER);
             $stmt->execute();
@@ -186,7 +133,7 @@ if ($result) {
         // Add payment methods for that user
         $query = 'INSERT INTO payment_methods (name, icon, "order", user_id) VALUES (:name, :icon, :order, :user_id)';
         $stmt = $db->prepare($query);
-        foreach ($payment_methods as $index => $payment_method) {
+        foreach (default_payment_methods($language) as $index => $payment_method) {
             $stmt->bindValue(':name', $payment_method['name'], SQLITE3_TEXT);
             $stmt->bindValue(':icon', $payment_method['icon'], SQLITE3_TEXT);
             $stmt->bindValue(':order', $index + 1, SQLITE3_INTEGER);

--- a/includes/default_names.php
+++ b/includes/default_names.php
@@ -1,0 +1,268 @@
+<?php
+/*
+  The categories and payment methods a new account starts with, in the language
+  of that account.
+
+  The lists were repeated verbatim in every place that creates an account —
+  registration.php, endpoints/admin/adduser.php and
+  includes/oidc/oidc_create_user.php — and every copy was English. Somebody who
+  registered in German got an application that was German everywhere except in
+  its own data, on the very first screen they saw.
+
+  The categories and the generic payment methods are held here as translation
+  keys and resolved once, at the moment the account is created. What is stored
+  is ordinary text the owner renames, reorders and deletes like any other row,
+  so changing the account language later never rewrites it — the same contract
+  the rows have always had.
+
+  Brand names — PayPal, SEPA, Klarna — are the same word in every language and
+  stay literal.
+
+  Currencies are deliberately not here. Their names are a separate list with a
+  separate problem (a currency is identified by its ISO code, not by its name),
+  and folding them in would make this change about something else.
+*/
+
+/**
+ * Translation keys of the default categories, in display order.
+ *
+ * The keys are the contract; the English strings live in the language files
+ * like every other translation. "no_category" is an existing key, translated
+ * in every language file already.
+ *
+ * @var string[]
+ */
+const DEFAULT_CATEGORY_KEYS = [
+    'no_category',
+    'category_entertainment',
+    'category_music',
+    'category_utilities',
+    'category_food_and_beverages',
+    'category_health_and_wellbeing',
+    'category_productivity',
+    'category_banking',
+    'category_transport',
+    'category_education',
+    'category_insurance',
+    'category_gaming',
+    'category_news_and_magazines',
+    'category_software',
+    'category_technology',
+    'category_cloud_services',
+    'category_charity_and_donations',
+];
+
+/**
+ * The default payment methods, in display order.
+ *
+ * A generic term — "Credit Card", "Bank Transfer", "Direct Debit", "Money" —
+ * reads differently to a German and to an English speaker, so it carries a
+ * translation "key". A brand is the same word in every language, so it keeps a
+ * literal "name".
+ *
+ * @var array<int, array{name?: string, key?: string, icon: string}>
+ */
+const DEFAULT_PAYMENT_METHODS = [
+    ['name' => 'PayPal', 'icon' => 'images/uploads/icons/paypal.png'],
+    ['key' => 'payment_method_credit_card', 'icon' => 'images/uploads/icons/creditcard.png'],
+    ['key' => 'payment_method_bank_transfer', 'icon' => 'images/uploads/icons/banktransfer.png'],
+    ['key' => 'payment_method_direct_debit', 'icon' => 'images/uploads/icons/directdebit.png'],
+    ['key' => 'payment_method_money', 'icon' => 'images/uploads/icons/money.png'],
+    ['name' => 'Google Pay', 'icon' => 'images/uploads/icons/googlepay.png'],
+    ['name' => 'Samsung Pay', 'icon' => 'images/uploads/icons/samsungpay.png'],
+    ['name' => 'Apple Pay', 'icon' => 'images/uploads/icons/applepay.png'],
+    ['name' => 'Crypto', 'icon' => 'images/uploads/icons/crypto.png'],
+    ['name' => 'Klarna', 'icon' => 'images/uploads/icons/klarna.png'],
+    ['name' => 'Amazon Pay', 'icon' => 'images/uploads/icons/amazonpay.png'],
+    ['name' => 'SEPA', 'icon' => 'images/uploads/icons/sepa.png'],
+    ['name' => 'Skrill', 'icon' => 'images/uploads/icons/skrill.png'],
+    ['name' => 'Sofort', 'icon' => 'images/uploads/icons/sofort.png'],
+    ['name' => 'Stripe', 'icon' => 'images/uploads/icons/stripe.png'],
+    ['name' => 'Affirm', 'icon' => 'images/uploads/icons/affirm.png'],
+    ['name' => 'AliPay', 'icon' => 'images/uploads/icons/alipay.png'],
+    ['name' => 'Elo', 'icon' => 'images/uploads/icons/elo.png'],
+    ['name' => 'Facebook Pay', 'icon' => 'images/uploads/icons/facebookpay.png'],
+    ['name' => 'GiroPay', 'icon' => 'images/uploads/icons/giropay.png'],
+    ['name' => 'iDeal', 'icon' => 'images/uploads/icons/ideal.png'],
+    ['name' => 'Union Pay', 'icon' => 'images/uploads/icons/unionpay.png'],
+    ['name' => 'Interac', 'icon' => 'images/uploads/icons/interac.png'],
+    ['name' => 'WeChat', 'icon' => 'images/uploads/icons/wechat.png'],
+    ['name' => 'Paysafe', 'icon' => 'images/uploads/icons/paysafe.png'],
+    ['name' => 'Poli', 'icon' => 'images/uploads/icons/poli.png'],
+    ['name' => 'Qiwi', 'icon' => 'images/uploads/icons/qiwi.png'],
+    ['name' => 'ShopPay', 'icon' => 'images/uploads/icons/shoppay.png'],
+    ['name' => 'Venmo', 'icon' => 'images/uploads/icons/venmo.png'],
+    ['name' => 'VeriFone', 'icon' => 'images/uploads/icons/verifone.png'],
+    ['name' => 'WebMoney', 'icon' => 'images/uploads/icons/webmoney.png'],
+];
+
+/**
+ * The translation table of one specific language.
+ *
+ * translate() answers in the language of the current request, which is not the
+ * language of the account being created: an administrator working in English
+ * creates an account for somebody whose language is German, and an identity
+ * provider names the language of an account nobody is looking at yet.
+ *
+ * A key the language file does not carry falls back to English, so a
+ * translation that has not been updated yet produces English rather than
+ * nothing.
+ *
+ * @param string $language
+ * @return array<string, string>
+ */
+function default_names_translations($language)
+{
+    static $tables = [];
+
+    // The value reaches this from a form field, an OIDC claim or the user
+    // table, and it decides a file name, so it is not taken on trust: anything
+    // that is not a plain identifier with a translation file is English, which
+    // is what the callers stored before.
+    $name = strtolower(str_replace('-', '_', trim((string) $language)));
+
+    if (preg_match('/^[a-z]{2}(_[a-z]{2,4})?$/', $name) !== 1
+        || !is_file(__DIR__ . '/i18n/' . $name . '.php')) {
+        $name = 'en';
+    }
+
+    if (!isset($tables[$name])) {
+        // The language files assign $i18n; required from inside a function it
+        // stays local, which is what makes loading a second language safe.
+        $i18n = [];
+        require __DIR__ . '/i18n/' . $name . '.php';
+        $table = $i18n;
+
+        if ($name !== 'en') {
+            $i18n = [];
+            require __DIR__ . '/i18n/en.php';
+            $table += $i18n;
+        }
+
+        $tables[$name] = $table;
+    }
+
+    return $tables[$name];
+}
+
+/**
+ * The default categories in one language, in display order.
+ *
+ * @param string $language
+ * @return string[]
+ */
+function default_categories($language)
+{
+    $translations = default_names_translations($language);
+
+    $categories = [];
+    foreach (DEFAULT_CATEGORY_KEYS as $key) {
+        $categories[] = $translations[$key] ?? $key;
+    }
+
+    return $categories;
+}
+
+/**
+ * The default payment methods in one language, in display order.
+ *
+ * @param string $language
+ * @return array<int, array{name: string, icon: string}>
+ */
+function default_payment_methods($language)
+{
+    $translations = default_names_translations($language);
+
+    $methods = [];
+    foreach (DEFAULT_PAYMENT_METHODS as $method) {
+        $methods[] = [
+            'name' => isset($method['key'])
+                ? ($translations[$method['key']] ?? $method['key'])
+                : $method['name'],
+            'icon' => $method['icon'],
+        ];
+    }
+
+    return $methods;
+}
+
+/**
+ * Renames the English default rows of the first account into its language.
+ *
+ * The first account of an installation is the one case where the rows exist
+ * before a language does: createdatabase.php seeds the categories and payment
+ * methods while the database is being created, and migration 000020 gives them
+ * user_id 1, so registration.php never seeds them for that account. Its owner
+ * picks a language on the registration form — the first moment anybody states
+ * one — and gets English data anyway.
+ *
+ * Only a row whose name is still exactly the English default is touched, so
+ * this cannot rewrite something somebody named themselves, and only the name
+ * column changes: subscriptions reference a category and a payment method by
+ * id, never by name.
+ *
+ * @param SQLite3 $db
+ * @param int     $userId
+ * @param string  $language
+ * @return int how many rows were renamed
+ */
+function localize_default_names($db, $userId, $language)
+{
+    $renamed = 0;
+
+    $renamed += default_names_rename(
+        $db,
+        $db->prepare('UPDATE categories SET name = :name WHERE user_id = :user_id AND name = :english'),
+        $userId,
+        default_categories('en'),
+        default_categories($language)
+    );
+
+    $renamed += default_names_rename(
+        $db,
+        $db->prepare('UPDATE payment_methods SET name = :name WHERE user_id = :user_id AND name = :english'),
+        $userId,
+        array_column(default_payment_methods('en'), 'name'),
+        array_column(default_payment_methods($language), 'name')
+    );
+
+    return $renamed;
+}
+
+/**
+ * Runs one prepared rename over a pair of equally ordered name lists.
+ *
+ * @param SQLite3           $db
+ * @param SQLite3Stmt|false $stmt
+ * @param int               $userId
+ * @param string[]          $english   the name a still-default row carries
+ * @param string[]          $localized what it should say instead
+ * @return int how many rows were renamed
+ */
+function default_names_rename($db, $stmt, $userId, $english, $localized)
+{
+    if ($stmt === false) {
+        return 0;
+    }
+
+    $renamed = 0;
+
+    foreach ($english as $index => $englishName) {
+        // A brand, or a language that has no translation for this name yet.
+        if ($localized[$index] === $englishName) {
+            continue;
+        }
+
+        $stmt->bindValue(':name', $localized[$index], SQLITE3_TEXT);
+        $stmt->bindValue(':user_id', $userId, SQLITE3_INTEGER);
+        $stmt->bindValue(':english', $englishName, SQLITE3_TEXT);
+
+        if ($stmt->execute() !== false) {
+            $renamed += $db->changes();
+        }
+
+        $stmt->reset();
+    }
+
+    return $renamed;
+}

--- a/includes/i18n/de.php
+++ b/includes/i18n/de.php
@@ -503,6 +503,31 @@ $i18n = [
     "google_search_info" => "Fügt Google-Bildergebnisse (über SerpAPI) als zusätzliche Quelle in der Logo-Suche hinzu. Erstellen Sie ein kostenloses SerpAPI-Konto und fügen Sie hier Ihren API-Schlüssel ein.",
     "monthly_searches_used" => "Diesen Monat verbrauchte Suchanfragen",
     "monthly_requests_used" => "Diesen Monat verbrauchte API-Anfragen",
+
+    // Default categories a new account is created with. The list also starts
+    // with "no_category", which is translated further up.
+    "category_entertainment" => "Unterhaltung",
+    "category_music" => "Musik",
+    "category_utilities" => "Nebenkosten",
+    "category_food_and_beverages" => "Essen & Trinken",
+    "category_health_and_wellbeing" => "Gesundheit & Wohlbefinden",
+    "category_productivity" => "Produktivität",
+    "category_banking" => "Bankwesen",
+    "category_transport" => "Verkehr",
+    "category_education" => "Bildung",
+    "category_insurance" => "Versicherung",
+    "category_gaming" => "Spiele",
+    "category_news_and_magazines" => "Nachrichten & Zeitschriften",
+    "category_software" => "Software",
+    "category_technology" => "Technik",
+    "category_cloud_services" => "Cloud-Dienste",
+    "category_charity_and_donations" => "Spenden & Wohltätigkeit",
+    // Default payment methods a new account is created with. Only the generic
+    // ones are translated; a brand is the same word in every language.
+    "payment_method_credit_card" => "Kreditkarte",
+    "payment_method_bank_transfer" => "Überweisung",
+    "payment_method_direct_debit" => "Lastschrift",
+    "payment_method_money" => "Bargeld",
 ];
 
 

--- a/includes/i18n/en.php
+++ b/includes/i18n/en.php
@@ -505,6 +505,31 @@ $i18n = [
     "google_search_info" => "Adds Google image results (via SerpAPI) as an additional source in the subscription logo search. Create a free SerpAPI account and paste your API key here.",
     "monthly_searches_used" => "Searches used this month",
     "monthly_requests_used" => "API requests used this month",
+
+    // Default categories a new account is created with. The list also starts
+    // with "no_category", which is translated further up.
+    "category_entertainment" => "Entertainment",
+    "category_music" => "Music",
+    "category_utilities" => "Utilities",
+    "category_food_and_beverages" => "Food & Beverages",
+    "category_health_and_wellbeing" => "Health & Wellbeing",
+    "category_productivity" => "Productivity",
+    "category_banking" => "Banking",
+    "category_transport" => "Transport",
+    "category_education" => "Education",
+    "category_insurance" => "Insurance",
+    "category_gaming" => "Gaming",
+    "category_news_and_magazines" => "News & Magazines",
+    "category_software" => "Software",
+    "category_technology" => "Technology",
+    "category_cloud_services" => "Cloud Services",
+    "category_charity_and_donations" => "Charity & Donations",
+    // Default payment methods a new account is created with. Only the generic
+    // ones are translated; a brand is the same word in every language.
+    "payment_method_credit_card" => "Credit Card",
+    "payment_method_bank_transfer" => "Bank Transfer",
+    "payment_method_direct_debit" => "Direct Debit",
+    "payment_method_money" => "Money",
 ];
 
 

--- a/includes/oidc/oidc_create_user.php
+++ b/includes/oidc/oidc_create_user.php
@@ -47,16 +47,11 @@ $stmt->bindValue(':name', $username, SQLITE3_TEXT);
 $stmt->bindValue(':user_id', $newUserId, SQLITE3_INTEGER);
 $stmt->execute();
 
-// Categories
-$categories = [
-    'No category', 'Entertainment', 'Music', 'Utilities', 'Food & Beverages',
-    'Health & Wellbeing', 'Productivity', 'Banking', 'Transport', 'Education',
-    'Insurance', 'Gaming', 'News & Magazines', 'Software', 'Technology',
-    'Cloud Services', 'Charity & Donations'
-];
+require_once __DIR__ . '/../default_names.php';
 
+// Categories
 $stmt = $db->prepare("INSERT INTO categories (name, \"order\", user_id) VALUES (:name, :order, :user_id)");
-foreach ($categories as $index => $name) {
+foreach (default_categories($language) as $index => $name) {
     $stmt->bindValue(':name', $name, SQLITE3_TEXT);
     $stmt->bindValue(':order', $index + 1, SQLITE3_INTEGER);
     $stmt->bindValue(':user_id', $newUserId, SQLITE3_INTEGER);
@@ -64,42 +59,8 @@ foreach ($categories as $index => $name) {
 }
 
 // Payment Methods
-$payment_methods = [
-    ['name' => 'PayPal', 'icon' => 'images/uploads/icons/paypal.png'],
-    ['name' => 'Credit Card', 'icon' => 'images/uploads/icons/creditcard.png'],
-    ['name' => 'Bank Transfer', 'icon' => 'images/uploads/icons/banktransfer.png'],
-    ['name' => 'Direct Debit', 'icon' => 'images/uploads/icons/directdebit.png'],
-    ['name' => 'Money', 'icon' => 'images/uploads/icons/money.png'],
-    ['name' => 'Google Pay', 'icon' => 'images/uploads/icons/googlepay.png'],
-    ['name' => 'Samsung Pay', 'icon' => 'images/uploads/icons/samsungpay.png'],
-    ['name' => 'Apple Pay', 'icon' => 'images/uploads/icons/applepay.png'],
-    ['name' => 'Crypto', 'icon' => 'images/uploads/icons/crypto.png'],
-    ['name' => 'Klarna', 'icon' => 'images/uploads/icons/klarna.png'],
-    ['name' => 'Amazon Pay', 'icon' => 'images/uploads/icons/amazonpay.png'],
-    ['name' => 'SEPA', 'icon' => 'images/uploads/icons/sepa.png'],
-    ['name' => 'Skrill', 'icon' => 'images/uploads/icons/skrill.png'],
-    ['name' => 'Sofort', 'icon' => 'images/uploads/icons/sofort.png'],
-    ['name' => 'Stripe', 'icon' => 'images/uploads/icons/stripe.png'],
-    ['name' => 'Affirm', 'icon' => 'images/uploads/icons/affirm.png'],
-    ['name' => 'AliPay', 'icon' => 'images/uploads/icons/alipay.png'],
-    ['name' => 'Elo', 'icon' => 'images/uploads/icons/elo.png'],
-    ['name' => 'Facebook Pay', 'icon' => 'images/uploads/icons/facebookpay.png'],
-    ['name' => 'GiroPay', 'icon' => 'images/uploads/icons/giropay.png'],
-    ['name' => 'iDeal', 'icon' => 'images/uploads/icons/ideal.png'],
-    ['name' => 'Union Pay', 'icon' => 'images/uploads/icons/unionpay.png'],
-    ['name' => 'Interac', 'icon' => 'images/uploads/icons/interac.png'],
-    ['name' => 'WeChat', 'icon' => 'images/uploads/icons/wechat.png'],
-    ['name' => 'Paysafe', 'icon' => 'images/uploads/icons/paysafe.png'],
-    ['name' => 'Poli', 'icon' => 'images/uploads/icons/poli.png'],
-    ['name' => 'Qiwi', 'icon' => 'images/uploads/icons/qiwi.png'],
-    ['name' => 'ShopPay', 'icon' => 'images/uploads/icons/shoppay.png'],
-    ['name' => 'Venmo', 'icon' => 'images/uploads/icons/venmo.png'],
-    ['name' => 'VeriFone', 'icon' => 'images/uploads/icons/verifone.png'],
-    ['name' => 'WebMoney', 'icon' => 'images/uploads/icons/webmoney.png'],
-];
-
 $stmt = $db->prepare("INSERT INTO payment_methods (name, icon, \"order\", user_id) VALUES (:name, :icon, :order, :user_id)");
-foreach ($payment_methods as $index => $method) {
+foreach (default_payment_methods($language) as $index => $method) {
     $stmt->bindValue(':name', $method['name'], SQLITE3_TEXT);
     $stmt->bindValue(':icon', $method['icon'], SQLITE3_TEXT);
     $stmt->bindValue(':order', $index + 1, SQLITE3_INTEGER);

--- a/registration.php
+++ b/registration.php
@@ -11,6 +11,7 @@ require_once 'includes/i18n/' . $lang . '.php';
 
 require_once 'includes/version.php';
 require_once 'includes/theme_helpers.php';
+require_once 'includes/default_names.php';
 
 function validate($value)
 {
@@ -112,60 +113,6 @@ $currencies = [
     ['id' => 34, 'name' => 'New Taiwan Dollar', 'symbol' => 'NT$', 'code' => 'TWD'],
 ];
 
-$categories = [
-    ['id' => 1, 'name' => 'No category'],
-    ['id' => 2, 'name' => 'Entertainment'],
-    ['id' => 3, 'name' => 'Music'],
-    ['id' => 4, 'name' => 'Utilities'],
-    ['id' => 5, 'name' => 'Food & Beverages'],
-    ['id' => 6, 'name' => 'Health & Wellbeing'],
-    ['id' => 7, 'name' => 'Productivity'],
-    ['id' => 8, 'name' => 'Banking'],
-    ['id' => 9, 'name' => 'Transport'],
-    ['id' => 10, 'name' => 'Education'],
-    ['id' => 11, 'name' => 'Insurance'],
-    ['id' => 12, 'name' => 'Gaming'],
-    ['id' => 13, 'name' => 'News & Magazines'],
-    ['id' => 14, 'name' => 'Software'],
-    ['id' => 15, 'name' => 'Technology'],
-    ['id' => 16, 'name' => 'Cloud Services'],
-    ['id' => 17, 'name' => 'Charity & Donations'],
-];
-
-$payment_methods = [
-    ['id' => 1, 'name' => 'PayPal', 'icon' => 'images/uploads/icons/paypal.png'],
-    ['id' => 2, 'name' => 'Credit Card', 'icon' => 'images/uploads/icons/creditcard.png'],
-    ['id' => 3, 'name' => 'Bank Transfer', 'icon' => 'images/uploads/icons/banktransfer.png'],
-    ['id' => 4, 'name' => 'Direct Debit', 'icon' => 'images/uploads/icons/directdebit.png'],
-    ['id' => 5, 'name' => 'Money', 'icon' => 'images/uploads/icons/money.png'],
-    ['id' => 6, 'name' => 'Google Pay', 'icon' => 'images/uploads/icons/googlepay.png'],
-    ['id' => 7, 'name' => 'Samsung Pay', 'icon' => 'images/uploads/icons/samsungpay.png'],
-    ['id' => 8, 'name' => 'Apple Pay', 'icon' => 'images/uploads/icons/applepay.png'],
-    ['id' => 9, 'name' => 'Crypto', 'icon' => 'images/uploads/icons/crypto.png'],
-    ['id' => 10, 'name' => 'Klarna', 'icon' => 'images/uploads/icons/klarna.png'],
-    ['id' => 11, 'name' => 'Amazon Pay', 'icon' => 'images/uploads/icons/amazonpay.png'],
-    ['id' => 12, 'name' => 'SEPA', 'icon' => 'images/uploads/icons/sepa.png'],
-    ['id' => 13, 'name' => 'Skrill', 'icon' => 'images/uploads/icons/skrill.png'],
-    ['id' => 14, 'name' => 'Sofort', 'icon' => 'images/uploads/icons/sofort.png'],
-    ['id' => 15, 'name' => 'Stripe', 'icon' => 'images/uploads/icons/stripe.png'],
-    ['id' => 16, 'name' => 'Affirm', 'icon' => 'images/uploads/icons/affirm.png'],
-    ['id' => 17, 'name' => 'AliPay', 'icon' => 'images/uploads/icons/alipay.png'],
-    ['id' => 18, 'name' => 'Elo', 'icon' => 'images/uploads/icons/elo.png'],
-    ['id' => 19, 'name' => 'Facebook Pay', 'icon' => 'images/uploads/icons/facebookpay.png'],
-    ['id' => 20, 'name' => 'GiroPay', 'icon' => 'images/uploads/icons/giropay.png'],
-    ['id' => 21, 'name' => 'iDeal', 'icon' => 'images/uploads/icons/ideal.png'],
-    ['id' => 22, 'name' => 'Union Pay', 'icon' => 'images/uploads/icons/unionpay.png'],
-    ['id' => 23, 'name' => 'Interac', 'icon' => 'images/uploads/icons/interac.png'],
-    ['id' => 24, 'name' => 'WeChat', 'icon' => 'images/uploads/icons/wechat.png'],
-    ['id' => 25, 'name' => 'Paysafe', 'icon' => 'images/uploads/icons/paysafe.png'],
-    ['id' => 26, 'name' => 'Poli', 'icon' => 'images/uploads/icons/poli.png'],
-    ['id' => 27, 'name' => 'Qiwi', 'icon' => 'images/uploads/icons/qiwi.png'],
-    ['id' => 28, 'name' => 'ShopPay', 'icon' => 'images/uploads/icons/shoppay.png'],
-    ['id' => 29, 'name' => 'Venmo', 'icon' => 'images/uploads/icons/venmo.png'],
-    ['id' => 30, 'name' => 'VeriFone', 'icon' => 'images/uploads/icons/verifone.png'],
-    ['id' => 31, 'name' => 'WebMoney', 'icon' => 'images/uploads/icons/webmoney.png'],
-];
-
 $passwordMismatch = false;
 $usernameExists = false;
 $emailExists = false;
@@ -244,8 +191,8 @@ if (isset($_POST['username'])) {
                 // Add categories for that user
                 $query = 'INSERT INTO categories (name, "order", user_id) VALUES (:name, :order, :user_id)';
                 $stmt = $db->prepare($query);
-                foreach ($categories as $index => $category) {
-                    $stmt->bindValue(':name', $category['name'], SQLITE3_TEXT);
+                foreach (default_categories($language) as $index => $name) {
+                    $stmt->bindValue(':name', $name, SQLITE3_TEXT);
                     $stmt->bindValue(':order', $index + 1, SQLITE3_INTEGER);
                     $stmt->bindValue(':user_id', $userId, SQLITE3_INTEGER);
                     $stmt->execute();
@@ -254,7 +201,7 @@ if (isset($_POST['username'])) {
                 // Add payment methods for that user
                 $query = 'INSERT INTO payment_methods (name, icon, "order", user_id) VALUES (:name, :icon, :order, :user_id)';
                 $stmt = $db->prepare($query);
-                foreach ($payment_methods as $index => $payment_method) {
+                foreach (default_payment_methods($language) as $index => $payment_method) {
                     $stmt->bindValue(':name', $payment_method['name'], SQLITE3_TEXT);
                     $stmt->bindValue(':icon', $payment_method['icon'], SQLITE3_TEXT);
                     $stmt->bindValue(':order', $index + 1, SQLITE3_INTEGER);
@@ -313,6 +260,13 @@ if (isset($_POST['username'])) {
 
                     $requireValidation = true;
                 }
+            } else {
+                // The first account of an installation adopts the rows
+                // createdatabase.php seeded before anybody had stated a
+                // language, which is why it is not seeded above. This is the
+                // first moment a language is known, so the rows that are
+                // still the English default are renamed into it.
+                localize_default_names($db, $userId, $language);
             }
 
             $db->close();

--- a/tests/cases/default_names_test.php
+++ b/tests/cases/default_names_test.php
@@ -1,0 +1,304 @@
+<?php
+/*
+  A new account's categories and payment methods are in that account's language.
+
+  Every path that creates an account carried its own copy of the same English
+  list, so somebody who registered in German got an application that was German
+  everywhere except in its own data — on the dashboard, which is the first
+  screen they ever see. The lists are held as translation keys now and resolved
+  once, at the moment the account is created.
+
+  Two properties are worth guarding rather than glancing at:
+
+    - the fallback. There are thirty language files and these keys cannot be
+      translated into all of them at once, so a file without them has to answer
+      with the English string and never with the key itself.
+
+    - the first account. It is the one account whose rows exist before a
+      language does: createdatabase.php seeds them while the database is being
+      created, and migration 000020 hands them to user 1. Renaming them at
+      registration is the only moment the language is known and the rows are
+      still untouched.
+*/
+
+require_once WALLOS_ROOT . '/includes/default_names.php';
+
+/**
+ * The languages Wallos ships a translation file for.
+ *
+ * @return string[]
+ */
+function default_names_test_languages()
+{
+    $languages = [];
+
+    foreach (glob(WALLOS_ROOT . '/includes/i18n/*.php') as $file) {
+        $name = basename($file, '.php');
+
+        if ($name !== 'languages' && $name !== 'getlang') {
+            $languages[] = $name;
+        }
+    }
+
+    return $languages;
+}
+
+/**
+ * The raw translation table of one language file, read without going through
+ * the code under test.
+ *
+ * @param string $language
+ * @return array<string, string>
+ */
+function default_names_test_table($language)
+{
+    $i18n = [];
+    require WALLOS_ROOT . '/includes/i18n/' . $language . '.php';
+
+    return $i18n;
+}
+
+/**
+ * The names of one user's rows, in insertion order.
+ *
+ * @param SQLite3 $db
+ * @param string  $table 'categories' or 'payment_methods'
+ * @param int     $userId
+ * @return string[]
+ */
+function default_names_test_rows($db, $table, $userId)
+{
+    $statement = $table === 'categories'
+        ? $db->prepare('SELECT name FROM categories WHERE user_id = :userId ORDER BY id')
+        : $db->prepare('SELECT name FROM payment_methods WHERE user_id = :userId ORDER BY id');
+
+    $statement->bindValue(':userId', $userId, SQLITE3_INTEGER);
+    $result = $statement->execute();
+
+    $names = [];
+    while ($result && $row = $result->fetchArray(SQLITE3_ASSOC)) {
+        $names[] = $row['name'];
+    }
+
+    return $names;
+}
+
+wallos_test('the default categories are the account language, not English', function () {
+    $english = default_categories('en');
+    $german = default_categories('de');
+
+    assert_same(17, count($english), 'English still has every default category');
+    assert_same(17, count($german), 'German has every default category');
+
+    assert_same('No category', $english[0], 'the first category is the placeholder');
+    assert_same('Keine Kategorie', $german[0], 'and it is translated too');
+    assert_same('Entertainment', $english[1], 'English second category');
+    assert_same('Unterhaltung', $german[1], 'German second category');
+    assert_same('Essen & Trinken', $german[4], 'an ampersand name is translated whole');
+
+    assert_true($german !== $english, 'the two languages are not the same list');
+});
+
+wallos_test('the default payment methods translate the generic ones and keep the brands', function () {
+    $english = default_payment_methods('en');
+    $german = default_payment_methods('de');
+
+    assert_same(31, count($english), 'every default payment method is there');
+    assert_same(31, count($german), 'in every language');
+
+    assert_same('PayPal', $english[0]['name'], 'a brand in English');
+    assert_same('PayPal', $german[0]['name'], 'is the same brand in German');
+    assert_same('Credit Card', $english[1]['name'], 'a generic method in English');
+    assert_same('Kreditkarte', $german[1]['name'], 'is translated in German');
+    assert_same('Bargeld', $german[4]['name'], 'and so is the last generic one');
+
+    foreach ($english as $index => $method) {
+        assert_same($method['icon'], $german[$index]['icon'],
+            'the icon of ' . $method['name'] . ' does not depend on the language');
+        assert_true(strpos($method['icon'], 'images/uploads/icons/') === 0,
+            $method['name'] . ' keeps the icon path the rows are stored with');
+    }
+});
+
+wallos_test('a language that has not translated a name yet answers in English', function () {
+    // The property that makes this shippable without inventing translations:
+    // every language file that does not carry a key answers with the English
+    // string, and never with the key itself. Checked against the raw language
+    // file rather than against a fixed expectation, so it keeps holding as
+    // translations arrive.
+    $english = default_categories('en');
+    $englishMethods = default_payment_methods('en');
+    $languages = default_names_test_languages();
+
+    foreach ($languages as $language) {
+        $table = default_names_test_table($language);
+        $categories = default_categories($language);
+        $methods = default_payment_methods($language);
+
+        assert_same(17, count($categories), $language . ' has every default category');
+
+        foreach (DEFAULT_CATEGORY_KEYS as $index => $key) {
+            $expected = isset($table[$key]) ? $table[$key] : $english[$index];
+
+            assert_same($expected, $categories[$index],
+                $language . '/' . $key . ' is its own translation or the English one');
+            assert_true(!in_array($categories[$index], DEFAULT_CATEGORY_KEYS, true),
+                $language . '/' . $key . ' resolved to a name rather than to the key');
+        }
+
+        foreach (DEFAULT_PAYMENT_METHODS as $index => $method) {
+            if (!isset($method['key'])) {
+                assert_same($method['name'], $methods[$index]['name'],
+                    $language . ' leaves the brand ' . $method['name'] . ' alone');
+
+                continue;
+            }
+
+            $expected = isset($table[$method['key']])
+                ? $table[$method['key']]
+                : $englishMethods[$index]['name'];
+
+            assert_same($expected, $methods[$index]['name'],
+                $language . '/' . $method['key'] . ' is its own translation or the English one');
+        }
+    }
+
+    assert_true(count($languages) >= 29,
+        'every shipped language was checked (' . count($languages) . ')');
+});
+
+wallos_test('a language value that names no translation is English, not an error', function () {
+    $english = default_categories('en');
+
+    // The value arrives from a form field, an OIDC claim or the user table and
+    // it decides a file name, so a path must never come out the other end.
+    foreach (['', ' ', 'xx', 'not a language', '../i18n/en', 'en.php', '../../../etc/passwd', null] as $value) {
+        assert_same($english, default_categories($value),
+            var_export($value, true) . ' falls back to English');
+    }
+});
+
+wallos_test('a language written as a BCP-47 tag finds its file', function () {
+    // What a browser and an identity provider send. The file names use an
+    // underscore, and a language nobody can reach is a language nobody gets.
+    // "username" is a string the two Portuguese translations spell differently,
+    // so it says which file was loaded.
+    assert_same(default_names_test_table('pt_br')['username'],
+        default_names_translations('pt-BR')['username'], 'pt-BR is the pt_br file');
+    assert_same(default_names_test_table('pt')['username'],
+        default_names_translations('pt')['username'], 'and pt is still pt');
+    assert_true(default_names_test_table('pt')['username'] !== default_names_test_table('pt_br')['username'],
+        'the two spellings really are different, so the check above can fail');
+});
+
+wallos_test('the seeding paths no longer carry an English list of their own', function () {
+    // Three copies of the same list is how the English one survived being
+    // fixed twice before. The names live in one file now.
+    foreach (['registration.php', 'endpoints/admin/adduser.php', 'includes/oidc/oidc_create_user.php'] as $file) {
+        $source = file_get_contents(WALLOS_ROOT . '/' . $file);
+
+        assert_contains('default_categories($language)', $source,
+            $file . ' seeds the categories in the account language');
+        assert_contains('default_payment_methods($language)', $source,
+            $file . ' seeds the payment methods in the account language');
+        assert_not_contains("'Food & Beverages'", $source,
+            $file . ' has no English category list left');
+        assert_not_contains("'Charity & Donations'", $source,
+            $file . ' has no English category list left');
+        assert_not_contains("'Direct Debit'", $source,
+            $file . ' has no English payment method list left');
+    }
+
+    // The first account is the one the loop above cannot describe: it is not
+    // seeded at all, it is renamed.
+    assert_contains('localize_default_names($db, $userId, $language)',
+        file_get_contents(WALLOS_ROOT . '/registration.php'),
+        'registration.php localizes the rows the first account inherits');
+});
+
+wallos_test('the first account is renamed into its language, rows and all', function () {
+    // createdatabase.php seeded these rows and migration 000020 gave them to
+    // user 1; the test database is built by running both, so this is the real
+    // state a first registration finds.
+    $db = wallos_test_open_database();
+    wallos_test_create_user($db, 1, 'alice');
+
+    $before = default_names_test_rows($db, 'categories', 1);
+    assert_same(17, count($before), 'the installation seeded its categories');
+    assert_same('No category', $before[0], 'in English');
+    assert_same('Entertainment', $before[1], 'in English');
+
+    $renamed = localize_default_names($db, 1, 'de');
+
+    $after = default_names_test_rows($db, 'categories', 1);
+    assert_same(default_categories('de'), $after, 'every category now reads in German');
+
+    $methods = default_names_test_rows($db, 'payment_methods', 1);
+    assert_same('PayPal', $methods[0], 'the brand is untouched');
+    assert_same('Kreditkarte', $methods[1], 'the generic method is German');
+    assert_same('Überweisung', $methods[2], 'and so is the next one');
+
+    // 16 categories — "Software" is the same word in both languages, so that
+    // row is not written at all — and the 4 generic payment methods.
+    assert_same(20, $renamed, 'it reports what it renamed');
+
+    $db->close();
+});
+
+wallos_test('renaming leaves English accounts and other people\'s rows alone', function () {
+    $db = wallos_test_open_database();
+    wallos_test_create_user($db, 1, 'alice');
+
+    assert_same(0, localize_default_names($db, 1, 'en'),
+        'an English account has nothing to rename');
+    assert_same('Entertainment', default_names_test_rows($db, 'categories', 1)[1],
+        'and its rows are untouched');
+
+    // A second account's rows are its own, whatever language the first picks.
+    wallos_test_create_user($db, 2, 'bob');
+    $statement = $db->prepare('INSERT INTO categories (name, "order", user_id) VALUES (:name, 1, 2)');
+    $statement->bindValue(':name', 'Entertainment', SQLITE3_TEXT);
+    $statement->execute();
+
+    localize_default_names($db, 1, 'de');
+
+    assert_same(['Entertainment'], default_names_test_rows($db, 'categories', 2),
+        "the other account's row is not renamed");
+
+    $db->close();
+});
+
+wallos_test('a name somebody chose themselves is never rewritten', function () {
+    $db = wallos_test_open_database();
+    wallos_test_create_user($db, 1, 'alice');
+
+    $statement = $db->prepare("UPDATE categories SET name = 'Filme' WHERE user_id = 1 AND name = 'Entertainment'");
+    $statement->execute();
+
+    localize_default_names($db, 1, 'de');
+
+    $names = default_names_test_rows($db, 'categories', 1);
+    assert_same('Filme', $names[1], 'a renamed row keeps the name it was given');
+    assert_same('Musik', $names[2], 'while the untouched rows next to it are localized');
+
+    $db->close();
+});
+
+wallos_test('every key the seeding uses exists in English', function () {
+    // A typo in a key is invisible at runtime: it falls back to English, and
+    // the English table does not have it either, so the account is seeded with
+    // the key as its category name.
+    $english = default_names_test_table('en');
+
+    foreach (DEFAULT_CATEGORY_KEYS as $key) {
+        assert_true(isset($english[$key]) && $english[$key] !== '',
+            $key . ' has an English string');
+    }
+
+    foreach (DEFAULT_PAYMENT_METHODS as $method) {
+        if (isset($method['key'])) {
+            assert_true(isset($english[$method['key']]) && $english[$method['key']] !== '',
+                $method['key'] . ' has an English string');
+        }
+    }
+});


### PR DESCRIPTION
Every new account is seeded with seventeen English category names and a list of
English payment methods, whatever language was chosen — in `registration.php`,
in `endpoints/admin/adduser.php` and in `includes/oidc/oidc_create_user.php`.
So a German-speaking household gets an application that is German everywhere
except in its own data, on the first screen anybody sees.

There is a fourth list, and it is the one that matters most for the typical
install: `endpoints/cronjobs/createdatabase.php` seeds the categories at install
time and migration `000020` hands them to user 1, which is why `registration.php`
guards its own seeding with `if ($userId > 1)`. Without covering that, a
single-user instance — one person, one account — would see no change at all.
The first account is therefore *renamed* into its language at registration,
touching only rows that still carry the exact English default, and only that
user's rows.

### Shape

`includes/default_names.php` holds the names as translation keys and resolves
them once, at account creation, for that account's language. The three seeding
sites call it. Brand names — PayPal, SEPA, Klarna — stay literal, because they
are not words that translate.

**Only `en` and `de` carry the new keys.** The other language files are
untouched and answer with the English string, which is the same fallback
`translate()` already gives every other key. Sixteen keys across twenty-nine
remaining languages would be 464 strings, and **no name here was
machine-translated** — a translation nobody read is worse than an English word
people recognise. `no_category` needed nothing: it already exists everywhere.

This does not replace *Translate with AI*. That still covers renamed categories,
custom ones, and accounts that already exist. What changes is that the default
is right without configuring an AI provider first.

Currency names are deliberately left alone: a currency is identified by its ISO
code, and localizing the names is a different problem with a different data
source.

### Test

`tests/cases/default_names_test.php` covers the seeding paths, the English
fallback for an untranslated language, the first-account rename, and that a name
a user has already changed is never rewritten. Verified by breaking each part:
removing the German keys, dropping the English merge, removing the
`name = :english` guard, dropping the `user_id` from the rename, a typo in one
key, and making the rename a no-op — each fails its own case.

Composes with #1215 without conflict (test-merged, both suites green): with both,
an account an identity provider creates resolves its language from the `locale`
claim and is then seeded in it. Each also works on its own.
