### PR TITLE
feat: Improve update banners and release links

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -477,23 +477,27 @@ $loginDisabledAllowed = $userCount == 1 && $settings['registrations_open'] == 0;
                 if ($hasUpdate) {
                     ?>
                     <div class="updates-list">
-                        <p><?= translate('new_version_available', $i18n) ?>.</p>
+                        <p class="updates-list-title">
+                            <i class="fa-solid fa-arrow-up"></i>
+                            <?= translate('new_version_available', $i18n) ?>.
+                        </p>
                         <p>
                             <?= translate('current_version', $i18n) ?>:
                             <span>
-                                <?= $version ?>
-                                <a href="https://github.com/ellite/Wallos/releases/tag/<?= $version ?>" target="_blank">
-                                    <i class="fa-solid fa-external-link"></i>
+                                <?= htmlspecialchars($version) ?>
+                                <a href="https://github.com/ellite/Wallos/releases/tag/<?= htmlspecialchars($version) ?>"
+                                    target="_blank" title="<?= translate('external_url', $i18n) ?>" rel="noreferrer">
+                                    <i class="fa-solid fa-arrow-up-right-from-square"></i>
                                 </a>
                             </span>
                         </p>
                         <p>
                             <?= translate('latest_version', $i18n) ?>:
-                            <span>
-                                <?= $latestVersion ?>
-                                <a href="https://github.com/ellite/Wallos/releases/tag/<?= $latestVersion ?>"
-                                    target="_blank">
-                                    <i class="fa-solid fa-external-link"></i>
+                            <span class="updates-list-latest">
+                                <?= htmlspecialchars($latestVersion) ?>
+                                <a href="https://github.com/ellite/Wallos/releases/tag/<?= htmlspecialchars($latestVersion) ?>"
+                                    target="_blank" title="<?= translate('external_url', $i18n) ?>" rel="noreferrer">
+                                    <i class="fa-solid fa-arrow-up-right-from-square"></i>
                                 </a>
                             </span>
                         </p>

--- a/index.php
+++ b/index.php
@@ -117,11 +117,23 @@ while ($row = $result->fetchArray(SQLITE3_ASSOC)) {
                 if (version_compare($version, $latestVersion) == -1) {
                     ?>
                     <div class="update-banner">
-                    <?= translate('new_version_available', $i18n) ?>:
-                        <span><a href="https://github.com/ellite/Wallos/releases/tag/<?= htmlspecialchars($latestVersion) ?>"
-                        target="_blank" rel="noreferer">
-                        <?= htmlspecialchars($latestVersion) ?>
-                        </a></span>
+                        <div class="update-banner-icon">
+                            <i class="fa-solid fa-arrow-up"></i>
+                        </div>
+                        <div class="update-banner-text">
+                            <strong><?= translate('new_version_available', $i18n) ?></strong>
+                            <span>
+                                <?= translate('current_version', $i18n) ?>: <?= htmlspecialchars($version) ?>
+                                <i class="fa-solid fa-arrow-right"></i>
+                                <b><?= htmlspecialchars($latestVersion) ?></b>
+                            </span>
+                        </div>
+                        <a class="update-banner-link"
+                            href="https://github.com/ellite/Wallos/releases/tag/<?= htmlspecialchars($latestVersion) ?>"
+                            target="_blank" title="<?= translate('external_url', $i18n) ?>" rel="noreferrer">
+                            <?= translate('release_notes', $i18n) ?>
+                            <i class="fa-solid fa-arrow-up-right-from-square"></i>
+                        </a>
                     </div>
                     <?php
                 }

--- a/styles/dark-theme.css
+++ b/styles/dark-theme.css
@@ -182,14 +182,6 @@ select {
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath d='M2.5 4.5 6 8l3.5-3.5' fill='none' stroke='%238B94A7' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
 }
 
-.update-banner {
-    color: #FFF;
-}
-
-.update-banner>span>a {
-    color: #FFF;
-}
-
 .totp-qrcode-container {
     padding: 14px;
     border: 1px solid #DDD;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1320,8 +1320,33 @@ header #avatar {
 
 .credits-list>div>span,
 .updates-list>p>span {
-  color: #AAA;
+  color: var(--text-muted);
   font-size: 16px;
+}
+
+.updates-list>p.updates-list-title {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 10px;
+  font-weight: 500;
+}
+
+.updates-list>p.updates-list-title>i {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background-color: var(--main-color);
+  color: var(--text-color-inverted);
+  font-size: 12px;
+}
+
+.updates-list>p>span.updates-list-latest {
+  color: var(--main-color);
+  font-weight: 600;
 }
 
 .credits-list>div>span>a,
@@ -3220,22 +3245,114 @@ input[type="radio"]:checked+label::after {
 }
 
 .update-banner {
-  padding: 15px 20px;
-  background-color: var(--accent-color);
-  border: 1px solid var(--main-color);
+  position: relative;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 18px 14px 22px;
+  background-color: var(--box-background-color);
+  background-image: linear-gradient(135deg, rgba(var(--main-color-rgb), 0.14), rgba(var(--main-color-rgb), 0.04));
+  border: 1px solid rgba(var(--main-color-rgb), 0.3);
   border-radius: 12px;
   margin-bottom: 20px;
-  text-align: center;
   color: var(--text-color);
+  box-shadow: var(--box-shadow);
+  overflow: hidden;
 }
 
-.update-banner>span {
+.update-banner::before {
+  content: "";
+  position: absolute;
+  top: 0px;
+  bottom: 0px;
+  left: 0px;
+  width: 4px;
+  background-color: var(--main-color);
+}
+
+.update-banner-icon {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  background-color: var(--main-color);
+  color: var(--text-color-inverted);
+  font-size: 16px;
+  box-shadow: 0 0 0 4px rgba(var(--main-color-rgb), 0.15);
+}
+
+.update-banner-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0px;
+  flex: 1 1 auto;
+}
+
+.update-banner-text>strong {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.update-banner-text>span {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  font-size: 14px;
+  color: var(--text-muted);
+}
+
+.update-banner-text>span>i {
+  font-size: 11px;
+}
+
+.update-banner-text>span>b {
+  font-weight: 600;
+  color: var(--main-color);
+}
+
+.update-banner-link {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-radius: 8px;
+  background-color: var(--main-color);
+  color: var(--text-color-inverted);
+  font-size: 14px;
   font-weight: 500;
+  text-decoration: none;
+  transition: background-color 0.2s;
 }
 
-.update-banner>span>a {
-  color: var(--text-color);
-  text-decoration: underline;
+.update-banner-link:hover {
+  background-color: var(--hover-color);
+}
+
+.update-banner-link>i,
+.update-banner-link:hover>i {
+  color: var(--text-color-inverted);
+  font-size: 12px;
+}
+
+@media (max-width: 768px) {
+  .update-banner {
+    flex-wrap: wrap;
+  }
+
+  .update-banner-link {
+    width: 100%;
+    box-sizing: border-box;
+    justify-content: center;
+  }
 }
 
 .demo-banner {


### PR DESCRIPTION
## What this PR does

Refreshes the "update available" notices so the dashboard and the admin settings page share one visual treatment, and makes the version information readable at a glance instead of being a single line of undifferentiated text.

### Features

- **Dashboard banner redesigned.** Previously a centered line of text on a flat `--accent-color` fill. Now a card with a left accent bar, a circular icon, the version transition (`current → latest`), and a "Release Notes" call-to-action button.
- **Version transition is explicit.** The banner shows what you're on and what you'd move to, rather than only the new version number.
- **Admin settings notice.** Icon added to the heading and the latest version emphasised in `--main-color`, so the two version rows are distinguishable.
- **Release links made consistent.** Admin used `fa-external-link` while the rest of the app uses `fa-arrow-up-right-from-square`; all release links now match and carry `title` and `rel="noreferrer"`, following the convention already used in `about.php`.
- **Responsive.** The banner wraps under 768px with the button going full width.

### Technical notes

- **Theme-safe.** Every colour uses an existing CSS custom property, so the four alternate themes (`styles/themes/{green,purple,red,yellow}.css`) and the dark theme recolour automatically. No literal colour values were introduced.
- **No new i18n strings.** Reuses the existing `new_version_available`, `current_version`, `latest_version`, `release_notes` and `external_url` keys, which keeps the change out of the ~30 files in `includes/i18n/`.
- **Contrast fix.** `.updates-list>p>span` had a hardcoded `color: #AAA` — low contrast on the light background and wrong in dark mode. Now `var(--text-muted)`.
- **Dark theme cleanup.** Removed two overrides that forced `#FFF` against the old flat fill. One of them (`.update-banner>span>a`) no longer matched any element once the markup changed.
- **Escaping.** `$version` and `$latestVersion` were interpolated unescaped in `admin.php`; both now go through `htmlspecialchars()`. Also corrects a `rel="noreferer"` typo in `index.php`.
- `about.php` is intentionally untouched; its notice is left as-is.

### Screenshots

<img width="1990" height="960" alt="Wallos_-_Subscription_Tracker__127_0_0_1_8383__—_Wallos" src="https://github.com/user-attachments/assets/8cbc65e3-d2ff-48b3-b6cb-b501cc5bc230" />
<img width="1940" height="2308" alt="Wallos_-_Subscription_Tracker__127_0_0_1_8383__—_Wallos" src="https://github.com/user-attachments/assets/7fbb6dc4-d986-4457-a43d-db6b99ebc626" />
<img width="1942" height="1758" alt="Wallos_-_Subscription_Tracker__127_0_0_1_8383__—_Wallos" src="https://github.com/user-attachments/assets/126575af-782b-420b-9afa-c8e96b8ceed2" />
<img width="1954" height="922" alt="Wallos_-_Subscription_Tracker__127_0_0_1_8383__—_Wallos" src="https://github.com/user-attachments/assets/e8dbe19c-93a1-4d48-b87b-5fcc51ec4a46" />
<img width="1922" height="1360" alt="Wallos_-_Subscription_Tracker__127_0_0_1_8383__—_Wallos" src="https://github.com/user-attachments/assets/619d0073-5e4a-420c-9ddb-65e9db946336" />
<img width="1912" height="1010" alt="Wallos_-_Subscription_Tracker__127_0_0_1_8383__—_Wallos" src="https://github.com/user-attachments/assets/efa00b19-e299-45ef-970d-4bcefdc90217" />

### Testing

Verified by rendering the pages from source locally (`php -S`) with the admin table's `latest_version` set ahead of the app version, since the notices only render when `version_compare($version, $latestVersion) == -1` and the dashboard banner additionally requires an admin user with `update_notification` enabled.

- Dashboard banner and admin settings notice checked in the **default light** and **dark** themes
- Checked in the **green** theme to confirm the treatment recolours from the theme variables rather than hardcoded values
- **Mobile at 430px** — banner wraps, button goes full width
- `php -l` clean on `index.php` and `admin.php`
- Confirmed the notices remain hidden when the app is on the latest version